### PR TITLE
Code style formatting using black + isort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN poetry config virtualenvs.create false && poetry config virtualenvs.in-proje
 
 WORKDIR /code
 
-COPY pyproject.toml poetry.lock ./
+COPY tox.ini pyproject.toml poetry.lock ./
 RUN poetry install \
     # poetry artifacts cache cleanup nice-to-have
     && ( \

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,5 +1,5 @@
 from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError
 
 from app.helpers.jwt import decode_jwt_token

--- a/app/helpers/jwt.py
+++ b/app/helpers/jwt.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 from jose import jwt

--- a/app/main.py
+++ b/app/main.py
@@ -9,9 +9,7 @@ from app.routers import auth, base, servers, users
 def get_application():
     app_ = FastAPI(title="NewShades API", default_response_class=ORJSONResponse)
 
-    origins = [
-        "*"  # TODO: change this later
-    ]
+    origins = ["*"]  # TODO: change this later
 
     app_.add_middleware(
         CORSMiddleware,

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from fastapi.responses import ORJSONResponse
 from starlette.middleware.cors import CORSMiddleware
 
-from app.routers import servers, base, auth, users
+from app.routers import auth, base, servers, users
 
 
 def get_application():

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -3,7 +3,7 @@ import http
 from fastapi import APIRouter, Body, Depends
 
 from app.helpers.database import get_db
-from app.schemas.auth import AuthWalletSchema, AccessTokenSchema
+from app.schemas.auth import AccessTokenSchema, AuthWalletSchema
 from app.services.auth import generate_wallet_token
 
 router = APIRouter()

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -9,11 +9,12 @@ from app.services.auth import generate_wallet_token
 router = APIRouter()
 
 
-@router.post('/login',
-             response_description="Generate access token",
-             response_model=AccessTokenSchema,
-             status_code=http.HTTPStatus.CREATED
-             )
+@router.post(
+    "/login",
+    response_description="Generate access token",
+    response_model=AccessTokenSchema,
+    status_code=http.HTTPStatus.CREATED,
+)
 async def login_with_wallet(data: AuthWalletSchema = Body(...), db=Depends(get_db)):
     token = await generate_wallet_token(data.dict())
     response = AccessTokenSchema(access_token=token)

--- a/app/routers/servers.py
+++ b/app/routers/servers.py
@@ -13,12 +13,12 @@ from app.services.crud import create_item
 router = APIRouter()
 
 
-@router.post("",
-             response_description="Create new server",
-             response_model=ServerSchema,
-             status_code=http.HTTPStatus.CREATED)
-async def create_server(server: ServerCreateSchema = Body(...), db=Depends(get_db),
-                        current_user: User = Depends(get_current_user)):
+@router.post(
+    "", response_description="Create new server", response_model=ServerSchema, status_code=http.HTTPStatus.CREATED
+)
+async def create_server(
+    server: ServerCreateSchema = Body(...), db=Depends(get_db), current_user: User = Depends(get_current_user)
+):
     created_server = await create_item(server, result_obj=Server, current_user=current_user)
     return created_server
 

--- a/app/routers/servers.py
+++ b/app/routers/servers.py
@@ -7,7 +7,7 @@ from app.dependencies import get_current_user
 from app.helpers.database import get_db
 from app.models.server import Server
 from app.models.user import User
-from app.schemas.servers import ServerSchema, ServerCreateSchema
+from app.schemas.servers import ServerCreateSchema, ServerSchema
 from app.services.crud import create_item
 
 router = APIRouter()

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import Field, BaseModel
+from pydantic import BaseModel, Field
 
 
 class MessageSchema(BaseModel):

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -19,9 +19,9 @@ class AuthWalletSchema(BaseModel):
             "example": {
                 "message": {
                     "address": "0x1231237072081028432784128371234898237233",
-                    "signed_at": "2022-01-01T12:12:12.123Z"
+                    "signed_at": "2022-01-01T12:12:12.123Z",
                 },
-                "signature": "0x1231237072081028432784128371234898237233479"
+                "signature": "0x1231237072081028432784128371234898237233479",
             }
         }
 
@@ -35,6 +35,6 @@ class AccessTokenSchema(BaseModel):
         schema_extra = {
             "example": {
                 "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIweDI1MDVmYTg2MTQwMDhGNTNGQjg1YmE0RTgwREFiOUZEZTUyNjYyNTMiLCJleHAiOjE2NDIwMjg2MjR9.bDZW6RHWpkQpwqkDopjSoiNDc2sHglWQ2TjdkM_5F84",
-                "token_type": "bearer"
+                "token_type": "bearer",
             }
         }

--- a/app/schemas/base.py
+++ b/app/schemas/base.py
@@ -12,12 +12,12 @@ class PyObjectId(ObjectId):
     @classmethod
     def validate(cls, v):
         if not ObjectId.is_valid(v):
-            raise ValueError('Invalid ObjectID')
+            raise ValueError("Invalid ObjectID")
         return str(v)
 
     @classmethod
     def __modify_schema__(cls, field_schema):
-        field_schema.update(type='string')
+        field_schema.update(type="string")
 
 
 class APIBaseSchema(BaseModel):

--- a/app/schemas/servers.py
+++ b/app/schemas/servers.py
@@ -1,4 +1,4 @@
-from app.schemas.base import APIBaseSchema, APIBaseCreateSchema
+from app.schemas.base import APIBaseCreateSchema, APIBaseSchema
 
 
 class ServerSchema(APIBaseSchema):

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from app.schemas.base import APIBaseSchema, APIBaseCreateSchema
+from app.schemas.base import APIBaseCreateSchema, APIBaseSchema
 
 
 class UserSchema(APIBaseSchema):

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -3,7 +3,7 @@ import json
 import arrow
 
 from app.helpers.jwt import generate_jwt_token
-from app.helpers.w3 import get_wallet_address_from_signed_message, checksum_address
+from app.helpers.w3 import checksum_address, get_wallet_address_from_signed_message
 from app.schemas.users import UserCreateSchema
 from app.services.users import create_user, get_user_by_wallet_address
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -29,11 +29,7 @@ def app() -> FastAPI:
 @pytest.fixture
 async def client(app: FastAPI) -> AsyncClient:
     async with LifespanManager(app):
-        async with AsyncClient(
-                app=app,
-                base_url="http://testserver",
-                follow_redirects=True
-        ) as client:
+        async with AsyncClient(app=app, base_url="http://testserver", follow_redirects=True) as client:
             yield client
 
 
@@ -55,7 +51,7 @@ def private_key() -> bytes:
 
 @pytest.fixture(scope="module")
 def wallet(private_key: bytes) -> str:
-    priv = binascii.hexlify(private_key).decode('ascii')
+    priv = binascii.hexlify(private_key).decode("ascii")
     private_key = "0x" + priv
     acct = Account.from_key(private_key)
     return acct.address
@@ -63,19 +59,13 @@ def wallet(private_key: bytes) -> str:
 
 @pytest.fixture
 async def authorized_client(client: AsyncClient, private_key: bytes, wallet: str) -> AsyncClient:
-    message_data = {
-        "address": wallet,
-        "signed_at": arrow.utcnow().isoformat()
-    }
+    message_data = {"address": wallet, "signed_at": arrow.utcnow().isoformat()}
 
-    str_message = json.dumps(message_data, separators=(',', ':'))
+    str_message = json.dumps(message_data, separators=(",", ":"))
     message = encode_defunct(text=str_message)
     signed_message = Web3().eth.account.sign_message(message, private_key=private_key)
 
-    data = {
-        "message": message_data,
-        "signature": signed_message.signature
-    }
+    data = {"message": message_data, "signature": signed_message.signature}
 
     access_token = await generate_wallet_token(data)
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from web3 import Web3
 
-from app.helpers.database import get_db, get_client
+from app.helpers.database import get_client, get_db
 from app.main import get_application
 from app.services.auth import generate_wallet_token
 

--- a/app/tests/routers/test_auth.py
+++ b/app/tests/routers/test_auth.py
@@ -17,23 +17,15 @@ from app.models.user import User
 
 class TestAuthRoutes:
     @pytest.mark.asyncio
-    async def test_create_token_wallet_ok(self, app: FastAPI,
-                                          db: Database,
-                                          client: AsyncClient,
-                                          private_key: bytes,
-                                          wallet: str):
-        message_data = {
-            "address": wallet,
-            "signed_at": arrow.utcnow().isoformat()
-        }
-        str_message = json.dumps(message_data, separators=(',', ':'))
+    async def test_create_token_wallet_ok(
+        self, app: FastAPI, db: Database, client: AsyncClient, private_key: bytes, wallet: str
+    ):
+        message_data = {"address": wallet, "signed_at": arrow.utcnow().isoformat()}
+        str_message = json.dumps(message_data, separators=(",", ":"))
         message = encode_defunct(text=str_message)
         signed_message = Web3().eth.account.sign_message(message, private_key=private_key)  # type: SignedMessage
 
-        data = {
-            "message": message_data,
-            "signature": signed_message.signature.hex()
-        }
+        data = {"message": message_data, "signature": signed_message.signature.hex()}
 
         response = await client.post("/auth/login", json=data)
         assert response.status_code == 201
@@ -45,28 +37,20 @@ class TestAuthRoutes:
         decrypted_token = decode_jwt_token(token)
         token_user_id = decrypted_token.get("sub")
         assert token_user_id != wallet
-        user = await User.find_one({'_id': ObjectId(token_user_id)})
+        user = await User.find_one({"_id": ObjectId(token_user_id)})
         assert user is not None
         assert user.wallet_address == wallet
 
     @pytest.mark.asyncio
-    async def test_login_with_same_wallet(self, app: FastAPI,
-                                          db: Database,
-                                          client: AsyncClient,
-                                          private_key: bytes,
-                                          wallet: str):
-        message_data = {
-            "address": wallet,
-            "signed_at": arrow.utcnow().isoformat()
-        }
-        str_message = json.dumps(message_data, separators=(',', ':'))
+    async def test_login_with_same_wallet(
+        self, app: FastAPI, db: Database, client: AsyncClient, private_key: bytes, wallet: str
+    ):
+        message_data = {"address": wallet, "signed_at": arrow.utcnow().isoformat()}
+        str_message = json.dumps(message_data, separators=(",", ":"))
         message = encode_defunct(text=str_message)
         signed_message = Web3().eth.account.sign_message(message, private_key=private_key)  # type: SignedMessage
 
-        data = {
-            "message": message_data,
-            "signature": signed_message.signature.hex()
-        }
+        data = {"message": message_data, "signature": signed_message.signature.hex()}
 
         response = await client.post("/auth/login", json=data)
         assert response.status_code == 201
@@ -78,7 +62,7 @@ class TestAuthRoutes:
         decrypted_token = decode_jwt_token(token)
         token_user_id = decrypted_token.get("sub")
         assert token_user_id != wallet
-        user = await User.find_one({'_id': ObjectId(token_user_id)})
+        user = await User.find_one({"_id": ObjectId(token_user_id)})
         assert user is not None
         assert user.wallet_address == wallet
 
@@ -98,24 +82,16 @@ class TestAuthRoutes:
         assert user.wallet_address == wallet
 
     @pytest.mark.asyncio
-    async def test_login_wallet_with_lowercase_address(self, app: FastAPI,
-                                                       db: Database,
-                                                       client: AsyncClient,
-                                                       private_key: bytes,
-                                                       wallet: str):
-        message_data = {
-            "address": wallet.lower(),
-            "signed_at": arrow.utcnow().isoformat()
-        }
+    async def test_login_wallet_with_lowercase_address(
+        self, app: FastAPI, db: Database, client: AsyncClient, private_key: bytes, wallet: str
+    ):
+        message_data = {"address": wallet.lower(), "signed_at": arrow.utcnow().isoformat()}
 
-        str_message = json.dumps(message_data, separators=(',', ':'))
+        str_message = json.dumps(message_data, separators=(",", ":"))
         message = encode_defunct(text=str_message)
         signed_message = Web3().eth.account.sign_message(message, private_key=private_key)  # type: SignedMessage
 
-        data = {
-            "message": message_data,
-            "signature": signed_message.signature.hex()
-        }
+        data = {"message": message_data, "signature": signed_message.signature.hex()}
 
         response = await client.post("/auth/login", json=data)
         assert response.status_code == 201

--- a/app/tests/routers/test_base.py
+++ b/app/tests/routers/test_base.py
@@ -6,7 +6,6 @@ from pymongo.database import Database
 
 
 class TestBaseRouting:
-
     @pytest.mark.asyncio
     async def test_post_fields(self, app: FastAPI, db: Database, authorized_client: AsyncClient):
         server_name = "test"
@@ -14,17 +13,17 @@ class TestBaseRouting:
         assert response.status_code == 201
         json_response = response.json()
         assert json_response != {}
-        assert 'name' in json_response
-        assert 'id' in json_response
-        assert isinstance(json_response.get('id'), str)
+        assert "name" in json_response
+        assert "id" in json_response
+        assert isinstance(json_response.get("id"), str)
 
         # collection is private
-        assert 'collection_name' not in json_response
-        assert '_collection_name' not in json_response
+        assert "collection_name" not in json_response
+        assert "_collection_name" not in json_response
 
         # created_at is isoformat and utc
-        assert 'created_at' in json_response
-        assert isinstance(json_response.get('created_at'), str)
-        created_date = arrow.get(json_response.get('created_at'))
+        assert "created_at" in json_response
+        assert isinstance(json_response.get("created_at"), str)
+        created_date = arrow.get(json_response.get("created_at"))
         assert created_date is not None
         assert (arrow.utcnow() - created_date).seconds <= 2

--- a/app/tests/routers/test_main.py
+++ b/app/tests/routers/test_main.py
@@ -5,7 +5,6 @@ from httpx import AsyncClient
 
 @pytest.mark.asyncio
 class TestMainRoutes:
-
     async def test_api_status(self, app: FastAPI, client: AsyncClient):
         response = await client.get("/")
         assert response.status_code == 200

--- a/app/tests/routers/test_servers.py
+++ b/app/tests/routers/test_servers.py
@@ -24,10 +24,10 @@ class TestServerRoutes:
         assert response.status_code == 201
         json_response = response.json()
         assert json_response != {}
-        assert 'name' in json_response
-        assert 'id' in json_response
-        assert json_response['id'] is not None
-        assert json_response['name'] == server_name
+        assert "name" in json_response
+        assert "id" in json_response
+        assert json_response["id"] is not None
+        assert json_response["name"] == server_name
 
     @pytest.mark.asyncio
     async def test_create_server_right_objectid_type(self, app: FastAPI, db: Database, authorized_client: AsyncClient):
@@ -35,5 +35,5 @@ class TestServerRoutes:
         response = await authorized_client.post("/servers", json={"name": server_name})
         assert response.status_code == 201
         obj = await db["servers"].find_one()
-        assert type(obj['_id']) != str
-        assert type(obj['_id']) == ObjectId
+        assert type(obj["_id"]) != str
+        assert type(obj["_id"]) == ObjectId

--- a/app/tests/routers/test_users.py
+++ b/app/tests/routers/test_users.py
@@ -5,7 +5,6 @@ from pymongo.database import Database
 
 
 class TestUserRoutes:
-
     @pytest.mark.asyncio
     async def test_get_user_me(self, app: FastAPI, db: Database, authorized_client: AsyncClient):
         response = await authorized_client.get("/users/me")

--- a/app/tests/services/test_auth_service.py
+++ b/app/tests/services/test_auth_service.py
@@ -14,24 +14,18 @@ from app.services.auth import generate_wallet_token
 class TestAuthService:
     @pytest.mark.asyncio
     async def test_generate_wallet_token_ok(self, db, private_key: bytes, wallet: str):
-        message_data = {
-            "address": wallet,
-            "signed_at": arrow.utcnow().isoformat()
-        }
-        str_message = json.dumps(message_data, separators=(',', ':'))
+        message_data = {"address": wallet, "signed_at": arrow.utcnow().isoformat()}
+        str_message = json.dumps(message_data, separators=(",", ":"))
         message = encode_defunct(text=str_message)
         signed_message = Web3().eth.account.sign_message(message, private_key=private_key)
 
-        data = {
-            "message": message_data,
-            "signature": signed_message.signature
-        }
+        data = {"message": message_data, "signature": signed_message.signature}
 
         token = await generate_wallet_token(data)
         decrypted_token = decode_jwt_token(token)
         token_user_id = decrypted_token.get("sub")
         assert token_user_id != wallet
 
-        user = await User.find_one({'_id': ObjectId(token_user_id)})
+        user = await User.find_one({"_id": ObjectId(token_user_id)})
         assert user is not None
         assert user.wallet_address == wallet

--- a/app/tests/services/test_crud_service.py
+++ b/app/tests/services/test_crud_service.py
@@ -25,7 +25,7 @@ class TestCRUDService:
         created_user = await create_item(item=model, result_obj=User, current_user="")
         assert created_user is not None
         assert created_user.wallet_address == wallet_address
-        assert 'created_at' in created_user._fields
+        assert "created_at" in created_user._fields
         assert created_user.created_at is not None
         assert isinstance(created_user.created_at, datetime)
         created_date = arrow.get(created_user.created_at)

--- a/app/tests/services/test_users_service.py
+++ b/app/tests/services/test_users_service.py
@@ -5,7 +5,6 @@ from app.services.users import create_user
 
 
 class TestUsersService:
-
     @pytest.mark.asyncio
     async def test_create_user(self, db):
         wallet_address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
@@ -29,4 +28,4 @@ class TestUsersService:
         assert user.ens_name is not None
 
         # TODO: replace all tests and wallet addresses w/ test wallet. This is just for fun
-        assert user.ens_name == 'vitalik.eth'
+        assert user.ens_name == "vitalik.eth"

--- a/poetry.lock
+++ b/poetry.lock
@@ -129,6 +129,32 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "black"
+version = "21.12b0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+click = ">=7.1.2"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0,<1"
+platformdirs = ">=2"
+tomli = ">=0.2.6,<2.0.0"
+typing-extensions = [
+    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
+    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+python2 = ["typed-ast (>=1.4.3)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "certifi"
 version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -408,6 +434,48 @@ doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=7.1.9,<8.0.0)", "mdx-inclu
 test = ["pytest (>=6.2.4,<7.0.0)", "pytest-cov (>=2.12.0,<4.0.0)", "mypy (==0.910)", "flake8 (>=3.8.3,<4.0.0)", "black (==21.9b0)", "isort (>=5.0.6,<6.0.0)", "requests (>=2.24.0,<3.0.0)", "httpx (>=0.14.0,<0.19.0)", "email_validator (>=1.1.1,<2.0.0)", "sqlalchemy (>=1.3.18,<1.5.0)", "peewee (>=3.13.3,<4.0.0)", "databases[sqlite] (>=0.3.2,<0.6.0)", "orjson (>=3.2.1,<4.0.0)", "ujson (>=4.0.1,<5.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "flask (>=1.1.2,<3.0.0)", "anyio[trio] (>=3.2.1,<4.0.0)", "types-ujson (==0.1.1)", "types-orjson (==3.6.0)", "types-dataclasses (==0.1.7)"]
 
 [[package]]
+name = "flake8"
+version = "4.0.1"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.8.0,<2.9.0"
+pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
+name = "flake8-black"
+version = "0.2.3"
+description = "flake8 plugin to call black as a code style validator"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+black = "*"
+flake8 = ">=3.0.0"
+toml = "*"
+
+[[package]]
+name = "flake8-isort"
+version = "4.1.1"
+description = "flake8 plugin that integrates isort ."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+flake8 = ">=3.2.1,<5"
+isort = ">=4.3.5,<6"
+testfixtures = ">=6.8.0,<7"
+
+[package.extras]
+test = ["pytest-cov"]
+
+[[package]]
 name = "frozenlist"
 version = "1.2.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -528,6 +596,20 @@ multiaddr = ">=0.0.7"
 requests = ">=2.11"
 
 [[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
+
+[[package]]
 name = "jsonschema"
 version = "3.2.0"
 description = "An implementation of JSON Schema validation for Python"
@@ -567,6 +649,14 @@ lint = ["mypy (==0.910)", "flake8 (==4.0.1)", "flake8-bugbear (==21.9.2)", "pre-
 tests = ["pytest", "pytz", "simplejson"]
 
 [[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "motor"
 version = "2.5.1"
 description = "Non-blocking MongoDB driver for Tornado or asyncio"
@@ -601,6 +691,14 @@ description = "multidict implementation"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "netaddr"
@@ -641,6 +739,26 @@ python-versions = "*"
 six = ">=1.9.0"
 
 [[package]]
+name = "pathspec"
+version = "0.9.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.4.1"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+
+[[package]]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
@@ -677,6 +795,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pycodestyle"
+version = "2.8.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -706,6 +832,14 @@ typing-extensions = ">=3.7.4.3"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
+
+[[package]]
+name = "pyflakes"
+version = "2.4.0"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pymongo"
@@ -927,12 +1061,33 @@ anyio = ">=3.0.0,<4"
 full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests", "graphene"]
 
 [[package]]
+name = "testfixtures"
+version = "6.18.3"
+description = "A collection of helpers and mock objects for unit tests and doc tests."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.extras]
+build = ["setuptools-git", "wheel", "twine"]
+docs = ["sphinx", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
+test = ["pytest (>=3.6)", "pytest-cov", "pytest-django", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tomli"
+version = "1.2.3"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "toolz"
@@ -1078,7 +1233,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "9a24ec215707697ba839ea2e0ce1e0853dc36366ee2d69ab0dc16beeda4c8c50"
+content-hash = "3d50e6cafce78a82eb36bf3273181f55f078ffcb2d3c8e6f3499237b9c8f7f1e"
 
 [metadata.files]
 aiohttp = [
@@ -1193,6 +1348,10 @@ base58 = [
 ]
 bitarray = [
     {file = "bitarray-1.2.2.tar.gz", hash = "sha256:27a69ffcee3b868abab3ce8b17c69e02b63e722d4d64ffd91d659f81e9984954"},
+]
+black = [
+    {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
+    {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -1331,6 +1490,18 @@ fastapi = [
     {file = "fastapi-0.70.1-py3-none-any.whl", hash = "sha256:5367226c7bcd7bfb2e17edaf225fd9a983095b1372281e9a3eb661336fb93748"},
     {file = "fastapi-0.70.1.tar.gz", hash = "sha256:21d03979b5336375c66fa5d1f3126c6beca650d5d2166fbb78345a30d33c8d06"},
 ]
+flake8 = [
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
+flake8-black = [
+    {file = "flake8-black-0.2.3.tar.gz", hash = "sha256:c199844bc1b559d91195ebe8620216f21ed67f2cc1ff6884294c91a0d2492684"},
+    {file = "flake8_black-0.2.3-py3-none-any.whl", hash = "sha256:cc080ba5b3773b69ba102b6617a00cc4ecbad8914109690cfda4d565ea435d96"},
+]
+flake8-isort = [
+    {file = "flake8-isort-4.1.1.tar.gz", hash = "sha256:d814304ab70e6e58859bc5c3e221e2e6e71c958e7005239202fee19c24f82717"},
+    {file = "flake8_isort-4.1.1-py3-none-any.whl", hash = "sha256:c4e8b6dcb7be9b71a02e6e5d4196cefcef0f3447be51e82730fb336fff164949"},
+]
 frozenlist = [
     {file = "frozenlist-1.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:977a1438d0e0d96573fd679d291a1542097ea9f4918a8b6494b06610dfeefbf9"},
     {file = "frozenlist-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a8d86547a5e98d9edd47c432f7a14b0c5592624b496ae9880fb6332f34af1edc"},
@@ -1463,6 +1634,10 @@ ipfshttpclient = [
     {file = "ipfshttpclient-0.8.0a2-py3-none-any.whl", hash = "sha256:ce6bac0e3963c4ced74d7eb6978125362bb05bbe219088ca48f369ce14d3cc39"},
     {file = "ipfshttpclient-0.8.0a2.tar.gz", hash = "sha256:0d80e95ee60b02c7d414e79bf81a36fc3c8fbab74265475c52f70b2620812135"},
 ]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
 jsonschema = [
     {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
     {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
@@ -1473,6 +1648,10 @@ lru-dict = [
 marshmallow = [
     {file = "marshmallow-3.14.1-py3-none-any.whl", hash = "sha256:04438610bc6dadbdddb22a4a55bcc7f6f8099e69580b2e67f5a681933a1f4400"},
     {file = "marshmallow-3.14.1.tar.gz", hash = "sha256:4c05c1684e0e97fe779c62b91878f173b937fe097b356cd82f793464f5bc6138"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 motor = [
     {file = "motor-2.5.1-py3-none-any.whl", hash = "sha256:961fdceacaae2c7236c939166f66415be81be8bbb762da528386738de3a0f509"},
@@ -1556,6 +1735,10 @@ multidict = [
     {file = "multidict-5.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:c9631c642e08b9fff1c6255487e62971d8b8e821808ddd013d8ac058087591ac"},
     {file = "multidict-5.2.0.tar.gz", hash = "sha256:0dd1c93edb444b33ba2274b66f63def8a327d607c6c790772f448a53b6ea59ce"},
 ]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 netaddr = [
     {file = "netaddr-0.8.0-py2.py3-none-any.whl", hash = "sha256:9666d0232c32d2656e5e5f8d735f58fd6c7457ce52fc21c98d45f2af78f990ac"},
     {file = "netaddr-0.8.0.tar.gz", hash = "sha256:d6cc57c7a07b1d9d2e917aa8b36ae8ce61c35ba3fcd1b83ca31c5a0ee2b5a243"},
@@ -1592,6 +1775,14 @@ packaging = [
 ]
 parsimonious = [
     {file = "parsimonious-0.8.1.tar.gz", hash = "sha256:3add338892d580e0cb3b1a39e4a1b427ff9f687858fdd61097053742391a9f6b"},
+]
+pathspec = [
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+platformdirs = [
+    {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
+    {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -1643,6 +1834,10 @@ pyasn1 = [
     {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
     {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
     {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
 ]
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -1716,6 +1911,10 @@ pydantic = [
     {file = "pydantic-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cc6a4cb8a118ffec2ca5fcb47afbacb4f16d0ab8b7350ddea5e8ef7bcc53a16"},
     {file = "pydantic-1.9.0-py3-none-any.whl", hash = "sha256:085ca1de245782e9b46cefcf99deecc67d418737a1fd3f6a4f511344b613a5b3"},
     {file = "pydantic-1.9.0.tar.gz", hash = "sha256:742645059757a56ecd886faf4ed2441b9c0cd406079c2b4bee51bcc3fbcd510a"},
+]
+pyflakes = [
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pymongo = [
     {file = "pymongo-3.12.3-cp27-cp27m-macosx_10_14_intel.whl", hash = "sha256:c164eda0be9048f83c24b9b2656900041e069ddf72de81c17d874d0c32f6079f"},
@@ -1950,9 +2149,17 @@ starlette = [
     {file = "starlette-0.16.0-py3-none-any.whl", hash = "sha256:38eb24bf705a2c317e15868e384c1b8a12ca396e5a3c3a003db7e667c43f939f"},
     {file = "starlette-0.16.0.tar.gz", hash = "sha256:e1904b5d0007aee24bdd3c43994be9b3b729f4f58e740200de1d623f8c3a8870"},
 ]
+testfixtures = [
+    {file = "testfixtures-6.18.3-py2.py3-none-any.whl", hash = "sha256:6ddb7f56a123e1a9339f130a200359092bd0a6455e31838d6c477e8729bb7763"},
+    {file = "testfixtures-6.18.3.tar.gz", hash = "sha256:2600100ae96ffd082334b378e355550fef8b4a529a6fa4c34f47130905c7426d"},
+]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 toolz = [
     {file = "toolz-0.11.2-py3-none-any.whl", hash = "sha256:a5700ce83414c64514d82d60bcda8aabfde092d1c1a8663f9200c07fdcc6da8f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,25 @@ watchgod = "^0.7"
 web3 = "^5.26"
 
 [tool.poetry.dev-dependencies]
+black = { version = "*", allow-prereleases = true }
+isort = ">=5.10"
+flake8 = ">=4.0"
+flake8-black = ">=0.2"
+flake8-isort = ">=4.1"
 pytest = "^6.2"
 pytest-asyncio = "^0.16"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 120
+target_version = ["py39"]
+include = '\.pyi?$'
+exclude = '\.git/|\.mypy_cache/|\.venv/|\.pytest_cache/|\.vscode/|__pycache__/'
+
+[tool.isort]
+profile = "black"
+line_length = 120
+skip = ".git,.mypy_cache,.venv,.pytest_cache,.vscode,__pycache__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,5 @@ exclude = '\.git/|\.mypy_cache/|\.venv/|\.pytest_cache/|\.vscode/|__pycache__/'
 [tool.isort]
 profile = "black"
 line_length = 120
+known_first_party = "app"
 skip = ".git,.mypy_cache,.venv,.pytest_cache,.vscode,__pycache__"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E501, E203, W503
+exclude = .git,.mypy_cache,.venv,.pytest_cache,.vscode,__pycache__
+max-line-length = 120


### PR DESCRIPTION
* Added code style formatting using `black` and `isort`.
  * https://github.com/psf/black (The Uncompromising Code Formatter)
  * https://pycqa.github.io/isort (sorts imports alphabetically, and automatically separated into sections and by type)

* Added `flake8` to dev-dependencies (incl. `flake8-black` + `flake8-isort`) for future linting (and potential editor niceness / developer delightness). 
  * Note: Since `flake8` doesn't support PEP 518 (`pyproject.toml`) configuration yet, we'll have to deal with pesky `tox.ini` (or `.flake8` / `setup.cfg`) files for the time being.

### Rationale
My take is that it may be good to apply these kinds of tooling on projects from the get-go as soon as possible to build some kind of understanding of how to align devs work, even if they're coming from different schools. I think black has done a great job at creating as few options as possible so that devs won't have to end up in endless discussions regarding "single quotes vs double quotes", "2 spaces vs 4 spaces", "trailing comma at end of arrays or not", "how many newlines should there be before a new function outside of a class", etc. 

Using tools such as `black` and `isort` in new projects (I'm not full-on advocating to always reformat existing larger codebases though) should make us avoid potential discussions regarding what code styles people prefer. Also makes PR:s / code diffs cleaner.

Getting things like that in early is usually easier than later having to deal with politics around different code styles to choose later on, and also making a larger dent if having to deal with merge conflicts to a larger extent if code formatting ruling isn't applied very early on.

> “Any color you like. Black.”