### PR TITLE
Add basic channels creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ cython_debug/
 
 # PyCharm
 .idea/
+
+# Mac OS files
+.DS_Store

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from fastapi.responses import ORJSONResponse
 from starlette.middleware.cors import CORSMiddleware
 
-from app.routers import servers, base, auth, users
+from app.routers import servers, base, auth, users, channels
 
 
 def get_application():
@@ -23,8 +23,9 @@ def get_application():
 
     app_.include_router(base.router)
     app_.include_router(auth.router, prefix="/auth", tags=["auth"])
-    app_.include_router(servers.router, prefix="/servers", tags=["servers"])
     app_.include_router(users.router, prefix="/users", tags=["users"])
+    app_.include_router(servers.router, prefix="/servers", tags=["servers"])
+    app_.include_router(channels.router, prefix="/channels", tags=["channels"])
 
     return app_
 

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -8,7 +8,7 @@ from app.models.user import User
 
 @instance.register
 class Channel(APIDocument):
-    kind: str = fields.StrField(validate=validate.OneOf(['dm', 'server']), required=True)  # TODO: make enum?
+    kind: str = fields.StrField(validate=validate.OneOf(["dm", "server"]), required=True)  # TODO: make enum?
     owner = fields.ReferenceField(User, required=True)
 
     class Meta:

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -1,0 +1,32 @@
+from umongo import fields, validate
+
+from app.helpers.database import instance
+from app.models.base import APIDocument
+from app.models.server import Server
+from app.models.user import User
+
+
+@instance.register
+class Channel(APIDocument):
+    kind: str = fields.StrField(validate=validate.OneOf(['dm', 'server']), required=True)  # TODO: make enum?
+    owner = fields.ReferenceField(User, required=True)
+
+    class Meta:
+        abstract = True
+
+
+@instance.register
+class DMChannel(Channel):
+    members = fields.ListField(fields.ReferenceField(User), required=True)
+
+    class Meta:
+        collection_name = "channels"
+
+
+@instance.register
+class ServerChannel(Channel):
+    server = fields.ReferenceField(Server, required=True)
+    name = fields.StrField(required=True)
+
+    class Meta:
+        collection_name = "channels"

--- a/app/models/server.py
+++ b/app/models/server.py
@@ -2,11 +2,14 @@ from umongo import fields
 
 from app.helpers.database import instance
 from app.models.base import APIDocument
+from app.models.user import User
 
 
 @instance.register
 class Server(APIDocument):
-    name = fields.StrField()
+    name = fields.StrField(required=True)
+
+    owner = fields.ReferenceField(User, required=True)
 
     class Meta:
         collection_name = "servers"

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -6,18 +6,21 @@ from fastapi import APIRouter, Body, Depends
 from app.dependencies import get_current_user
 from app.helpers.database import get_db
 from app.models.user import User
-from app.schemas.channels import ServerChannelSchema, DMChannelSchema, \
-    ServerChannelCreateSchema, DMChannelCreateSchema
+from app.schemas.channels import DMChannelCreateSchema, DMChannelSchema, ServerChannelCreateSchema, ServerChannelSchema
 from app.services.channels import create_channel
 
 router = APIRouter()
 
 
-@router.post("",
-             response_description="Create new channel",
-             response_model=Union[ServerChannelSchema, DMChannelSchema],
-             status_code=http.HTTPStatus.CREATED)
-async def post_create_channel(channel: Union[ServerChannelCreateSchema, DMChannelCreateSchema] = Body(...),
-                              db=Depends(get_db),
-                              current_user: User = Depends(get_current_user)):
+@router.post(
+    "",
+    response_description="Create new channel",
+    response_model=Union[ServerChannelSchema, DMChannelSchema],
+    status_code=http.HTTPStatus.CREATED,
+)
+async def post_create_channel(
+    channel: Union[ServerChannelCreateSchema, DMChannelCreateSchema] = Body(...),
+    db=Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     return await create_channel(channel, current_user=current_user)

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -1,0 +1,23 @@
+import http
+from typing import Union
+
+from fastapi import APIRouter, Body, Depends
+
+from app.dependencies import get_current_user
+from app.helpers.database import get_db
+from app.models.user import User
+from app.schemas.channels import ServerChannelSchema, DMChannelSchema, \
+    ServerChannelCreateSchema, DMChannelCreateSchema
+from app.services.channels import create_channel
+
+router = APIRouter()
+
+
+@router.post("",
+             response_description="Create new channel",
+             response_model=Union[ServerChannelSchema, DMChannelSchema],
+             status_code=http.HTTPStatus.CREATED)
+async def post_create_channel(channel: Union[ServerChannelCreateSchema, DMChannelCreateSchema] = Body(...),
+                              db=Depends(get_db),
+                              current_user: User = Depends(get_current_user)):
+    return await create_channel(channel, current_user=current_user)

--- a/app/routers/servers.py
+++ b/app/routers/servers.py
@@ -17,9 +17,9 @@ router = APIRouter()
              response_description="Create new server",
              response_model=ServerSchema,
              status_code=http.HTTPStatus.CREATED)
-async def create_server(server: ServerCreateSchema = Body(...), db=Depends(get_db),
-                        current_user: User = Depends(get_current_user)):
-    created_server = await create_item(server, result_obj=Server, current_user=current_user)
+async def post_create_server(server: ServerCreateSchema = Body(...), db=Depends(get_db),
+                             current_user: User = Depends(get_current_user)):
+    created_server = await create_item(server, result_obj=Server, current_user=current_user, user_field='owner')
     return created_server
 
 

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -8,6 +8,6 @@ from app.schemas.users import UserSchema
 router = APIRouter()
 
 
-@router.get("/me", response_description="Get user info", response_model=UserSchema)
+@router.get("/me", response_description="Get user info", response_model=UserSchema, summary="Get current user info")
 async def get_user_me(db=Depends(get_db), current_user: User = Depends(get_current_user)):
     return current_user

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,17 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 
 from app.dependencies import get_current_user
 from app.helpers.database import get_db
 from app.models.user import User
 from app.schemas.users import UserSchema
-from app.services.users import get_user_by_id
 
 router = APIRouter()
 
 
 @router.get("/me", response_description="Get user info", response_model=UserSchema)
 async def get_user_me(db=Depends(get_db), current_user: User = Depends(get_current_user)):
-    user = await get_user_by_id(user_id=current_user.id)
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-    return user
+    return current_user

--- a/app/schemas/base.py
+++ b/app/schemas/base.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from bson import ObjectId
 from pydantic import BaseModel, Field
+from umongo.frameworks.motor_asyncio import MotorAsyncIOReference
 
 
 class PyObjectId(ObjectId):
@@ -11,6 +12,8 @@ class PyObjectId(ObjectId):
 
     @classmethod
     def validate(cls, v):
+        if isinstance(v, MotorAsyncIOReference):
+            v = v.pk
         if not ObjectId.is_valid(v):
             raise ValueError('Invalid ObjectID')
         return str(v)

--- a/app/schemas/channels.py
+++ b/app/schemas/channels.py
@@ -2,7 +2,7 @@ from typing import List
 
 from pydantic import Field
 
-from app.schemas.base import APIBaseSchema, PyObjectId, APIBaseCreateSchema
+from app.schemas.base import APIBaseCreateSchema, APIBaseSchema, PyObjectId
 
 
 class ChannelSchema(APIBaseSchema):
@@ -19,7 +19,7 @@ class DMChannelSchema(ChannelSchema):
                 "id": "61e17018c3ee162141baf5c9",
                 "kind": "dm",
                 "members": ["61e17018c3ee162141baf5c1", "61e17018c3ee162141baf5c2", "61e17018c3ee162141baf5c3"],
-                "owner": "61e17018c3ee162141baf5c1"
+                "owner": "61e17018c3ee162141baf5c1",
             }
         }
 
@@ -35,7 +35,7 @@ class ServerChannelSchema(ChannelSchema):
                 "kind": "server",
                 "name": "🔥-shilling",
                 "server": "61e17018c3ee162141baf5c1",
-                "owner": "61e17018c3ee162141baf5c1"
+                "owner": "61e17018c3ee162141baf5c1",
             }
         }
 

--- a/app/schemas/channels.py
+++ b/app/schemas/channels.py
@@ -1,0 +1,53 @@
+from typing import List
+
+from pydantic import Field
+
+from app.schemas.base import APIBaseSchema, PyObjectId, APIBaseCreateSchema
+
+
+class ChannelSchema(APIBaseSchema):
+    kind: str
+    owner: PyObjectId = Field()
+
+
+class DMChannelSchema(ChannelSchema):
+    members: List[PyObjectId] = []
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "id": "61e17018c3ee162141baf5c9",
+                "kind": "dm",
+                "members": ["61e17018c3ee162141baf5c1", "61e17018c3ee162141baf5c2", "61e17018c3ee162141baf5c3"],
+                "owner": "61e17018c3ee162141baf5c1"
+            }
+        }
+
+
+class ServerChannelSchema(ChannelSchema):
+    server: PyObjectId = Field()
+    name: str = Field()
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "id": "61e17018c3ee162141baf5c9",
+                "kind": "server",
+                "name": "🔥-shilling",
+                "server": "61e17018c3ee162141baf5c1",
+                "owner": "61e17018c3ee162141baf5c1"
+            }
+        }
+
+
+class ChannelCreateSchema(APIBaseCreateSchema):
+    kind: str
+
+
+class DMChannelCreateSchema(ChannelCreateSchema):
+    members: List[str]
+
+
+class ServerChannelCreateSchema(ChannelCreateSchema):
+    server: str
+    name: str

--- a/app/schemas/servers.py
+++ b/app/schemas/servers.py
@@ -1,14 +1,18 @@
-from app.schemas.base import APIBaseSchema, APIBaseCreateSchema
+from pydantic import Field
+
+from app.schemas.base import APIBaseSchema, APIBaseCreateSchema, PyObjectId
 
 
 class ServerSchema(APIBaseSchema):
     name: str
+    owner: PyObjectId = Field()
 
     class Config:
         schema_extra = {
             "example": {
                 "id": "61e17018c3ee162141baf5c9",
                 "name": "Verbs",
+                "owner": "61e17018c3ee162141baf5c7"
             }
         }
 

--- a/app/services/channels.py
+++ b/app/services/channels.py
@@ -9,35 +9,33 @@ from app.schemas.channels import DMChannelCreateSchema, ServerChannelCreateSchem
 from app.services.crud import create_item, get_items
 
 
-async def create_dm_channel(
-        channel_model: DMChannelCreateSchema, current_user: User) -> Union[DMChannel, APIDocument]:
+async def create_dm_channel(channel_model: DMChannelCreateSchema, current_user: User) -> Union[DMChannel, APIDocument]:
     current_user_id = str(current_user.id)
     if current_user_id not in channel_model.members:
         channel_model.members.insert(0, current_user_id)
 
     # if same exact dm channel already exists, ignore
     filters = {
-        'owner': current_user.id,
-        'members': {'$all': [ObjectId(member) for member in channel_model.members]},
+        "owner": current_user.id,
+        "members": {"$all": [ObjectId(member) for member in channel_model.members]},
     }
     existing_dm_channels = await get_items(filters=filters, result_obj=DMChannel, current_user=current_user)
     if existing_dm_channels:
         # TODO: return 200 status code
         return existing_dm_channels[0]
 
-    return await create_item(channel_model, result_obj=DMChannel, current_user=current_user, user_field='owner')
+    return await create_item(channel_model, result_obj=DMChannel, current_user=current_user, user_field="owner")
 
 
 async def create_server_channel(
-        channel_model: ServerChannelCreateSchema,
-        current_user: User) -> Union[ServerChannel, APIDocument]:
-    return await create_item(channel_model, result_obj=ServerChannel, current_user=current_user,
-                             user_field='owner')
+    channel_model: ServerChannelCreateSchema, current_user: User
+) -> Union[ServerChannel, APIDocument]:
+    return await create_item(channel_model, result_obj=ServerChannel, current_user=current_user, user_field="owner")
 
 
 async def create_channel(
-        channel_model: Union[DMChannelCreateSchema, ServerChannelCreateSchema],
-        current_user: User) -> Union[Channel, APIDocument]:
+    channel_model: Union[DMChannelCreateSchema, ServerChannelCreateSchema], current_user: User
+) -> Union[Channel, APIDocument]:
     kind = channel_model.kind
     if kind == "dm":
         return await create_dm_channel(channel_model, current_user)

--- a/app/services/channels.py
+++ b/app/services/channels.py
@@ -1,0 +1,47 @@
+from typing import Union
+
+from bson import ObjectId
+
+from app.models.base import APIDocument
+from app.models.channel import Channel, DMChannel, ServerChannel
+from app.models.user import User
+from app.schemas.channels import DMChannelCreateSchema, ServerChannelCreateSchema
+from app.services.crud import create_item, get_items
+
+
+async def create_dm_channel(
+        channel_model: DMChannelCreateSchema, current_user: User) -> Union[DMChannel, APIDocument]:
+    current_user_id = str(current_user.id)
+    if current_user_id not in channel_model.members:
+        channel_model.members.insert(0, current_user_id)
+
+    # if same exact dm channel already exists, ignore
+    filters = {
+        'owner': current_user.id,
+        'members': {'$all': [ObjectId(member) for member in channel_model.members]},
+    }
+    existing_dm_channels = await get_items(filters=filters, result_obj=DMChannel, current_user=current_user)
+    if existing_dm_channels:
+        # TODO: return 200 status code
+        return existing_dm_channels[0]
+
+    return await create_item(channel_model, result_obj=DMChannel, current_user=current_user, user_field='owner')
+
+
+async def create_server_channel(
+        channel_model: ServerChannelCreateSchema,
+        current_user: User) -> Union[ServerChannel, APIDocument]:
+    return await create_item(channel_model, result_obj=ServerChannel, current_user=current_user,
+                             user_field='owner')
+
+
+async def create_channel(
+        channel_model: Union[DMChannelCreateSchema, ServerChannelCreateSchema],
+        current_user: User) -> Union[Channel, APIDocument]:
+    kind = channel_model.kind
+    if kind == "dm":
+        return await create_dm_channel(channel_model, current_user)
+    elif kind == "server":
+        return await create_server_channel(channel_model, current_user)
+    else:
+        raise Exception(f"unexpected channel kind: {kind}")

--- a/app/services/crud.py
+++ b/app/services/crud.py
@@ -1,4 +1,4 @@
-from typing import Type, Optional
+from typing import Optional, Type
 
 from bson import ObjectId
 
@@ -7,10 +7,9 @@ from app.models.user import User
 from app.schemas.base import APIBaseCreateSchema
 
 
-async def create_item(item: APIBaseCreateSchema,
-                      result_obj: Type[APIDocument],
-                      current_user: User,
-                      user_field: Optional[str] = 'user') -> APIDocument:
+async def create_item(
+    item: APIBaseCreateSchema, result_obj: Type[APIDocument], current_user: User, user_field: Optional[str] = "user"
+) -> APIDocument:
     db_object = result_obj(**item.dict())
     if user_field:
         db_object[user_field] = current_user

--- a/app/services/crud.py
+++ b/app/services/crud.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Type, Optional
 
 from bson import ObjectId
 
@@ -7,8 +7,13 @@ from app.models.user import User
 from app.schemas.base import APIBaseCreateSchema
 
 
-async def create_item(item: APIBaseCreateSchema, result_obj: Type[APIDocument], current_user: User) -> APIDocument:
+async def create_item(item: APIBaseCreateSchema,
+                      result_obj: Type[APIDocument],
+                      current_user: User,
+                      user_field: Optional[str] = 'user') -> APIDocument:
     db_object = result_obj(**item.dict())
+    if user_field:
+        db_object[user_field] = current_user
     await db_object.commit()
     return db_object
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -14,7 +14,10 @@ from web3 import Web3
 
 from app.helpers.database import get_db, get_client
 from app.main import get_application
+from app.models.user import User
+from app.schemas.users import UserCreateSchema
 from app.services.auth import generate_wallet_token
+from app.services.users import create_user
 
 
 @pytest.fixture
@@ -62,9 +65,14 @@ def wallet(private_key: bytes) -> str:
 
 
 @pytest.fixture
-async def authorized_client(client: AsyncClient, private_key: bytes, wallet: str) -> AsyncClient:
+async def current_user(private_key: bytes, wallet: str) -> User:
+    return await create_user(UserCreateSchema(wallet_address=wallet))
+
+
+@pytest.fixture
+async def authorized_client(client: AsyncClient, private_key: bytes, current_user: User) -> AsyncClient:
     message_data = {
-        "address": wallet,
+        "address": current_user.wallet_address,
         "signed_at": arrow.utcnow().isoformat()
     }
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -2,6 +2,7 @@ import binascii
 import json
 import os
 import secrets
+from typing import Union
 
 import arrow
 import pytest
@@ -14,9 +15,13 @@ from web3 import Web3
 
 from app.helpers.database import get_db, get_client
 from app.main import get_application
+from app.models.base import APIDocument
+from app.models.server import Server
 from app.models.user import User
+from app.schemas.servers import ServerCreateSchema
 from app.schemas.users import UserCreateSchema
 from app.services.auth import generate_wallet_token
+from app.services.crud import create_item
 from app.services.users import create_user
 
 
@@ -67,6 +72,12 @@ def wallet(private_key: bytes) -> str:
 @pytest.fixture
 async def current_user(private_key: bytes, wallet: str) -> User:
     return await create_user(UserCreateSchema(wallet_address=wallet))
+
+
+@pytest.fixture
+async def server(current_user: User) -> Union[Server, APIDocument]:
+    server_model = ServerCreateSchema(name="NewShades DAO")
+    return await create_item(server_model, result_obj=Server, current_user=current_user, user_field='owner')
 
 
 @pytest.fixture

--- a/app/tests/routers/test_channels.py
+++ b/app/tests/routers/test_channels.py
@@ -1,0 +1,102 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+from pymongo.database import Database
+
+from app.models.server import Server
+from app.models.user import User
+
+
+class TestChannelsRoutes:
+
+    @pytest.mark.asyncio
+    async def test_create_dm_channel(self, app: FastAPI, db: Database, current_user: User,
+                                     authorized_client: AsyncClient):
+        members = []
+        for x in range(3):
+            user = User(wallet_address=f"0x{x}")
+            await user.commit()
+            members.append(user)
+
+        data = {
+            "kind": "dm",
+            "members": [str(member.id) for member in members]
+        }
+
+        response = await authorized_client.post("/channels", json=data)
+        assert response.status_code == 201
+        json_response = response.json()
+        assert json_response != {}
+        assert 'kind' in json_response
+        assert json_response['kind'] == data['kind']
+        assert 'owner' in json_response
+        assert json_response['owner'] == str(current_user.id)
+        assert 'members' in json_response
+        assert all([member in json_response['members'] for member in data['members']])
+        assert str(current_user.id) in json_response['members']
+
+    @pytest.mark.asyncio
+    async def test_create_personal_dm_channel(self, app: FastAPI, db: Database, current_user: User,
+                                              authorized_client: AsyncClient):
+        data = {
+            "kind": "dm",
+            "members": []
+        }
+
+        response = await authorized_client.post("/channels", json=data)
+        assert response.status_code == 201
+        json_response = response.json()
+        assert json_response != {}
+        assert 'kind' in json_response
+        assert json_response['kind'] == data['kind']
+        assert 'owner' in json_response
+        assert json_response['owner'] == str(current_user.id)
+        assert 'members' in json_response
+        assert str(current_user.id) in json_response['members']
+
+    @pytest.mark.asyncio
+    async def test_create_multiple_personal_dm_channels(self, app: FastAPI, db: Database, current_user: User,
+                                                        authorized_client: AsyncClient):
+        data = {
+            "kind": "dm",
+            "members": []
+        }
+
+        response = await authorized_client.post("/channels", json=data)
+        assert response.status_code == 201
+        json_response = response.json()
+        assert json_response != {}
+        assert 'kind' in json_response
+        assert json_response['kind'] == data['kind']
+        assert 'owner' in json_response
+        assert json_response['owner'] == str(current_user.id)
+        assert 'members' in json_response
+        assert str(current_user.id) in json_response['members']
+        channel_id = json_response['id']
+
+        response = await authorized_client.post("/channels", json=data)
+        assert response.status_code == 201
+        json_response = response.json()
+        assert json_response['id'] == channel_id
+
+    @pytest.mark.asyncio
+    async def test_create_server_channel(self, app: FastAPI, db: Database, current_user: User, server: Server,
+                                         authorized_client: AsyncClient):
+        data = {
+            "kind": "server",
+            "name": "fancy-announcements",
+            "server": str(server.id),
+        }
+
+        response = await authorized_client.post("/channels", json=data)
+        assert response.status_code == 201
+        json_response = response.json()
+        assert json_response != {}
+        assert 'kind' in json_response
+        assert json_response['kind'] == data['kind']
+        assert 'owner' in json_response
+        assert json_response['owner'] == str(current_user.id)
+        assert 'name' in json_response
+        assert json_response['name'] == data['name']
+        assert 'server' in json_response
+        assert json_response['server'] == str(server.id)

--- a/app/tests/routers/test_channels.py
+++ b/app/tests/routers/test_channels.py
@@ -8,80 +8,74 @@ from app.models.user import User
 
 
 class TestChannelsRoutes:
-
     @pytest.mark.asyncio
-    async def test_create_dm_channel(self, app: FastAPI, db: Database, current_user: User,
-                                     authorized_client: AsyncClient):
+    async def test_create_dm_channel(
+        self, app: FastAPI, db: Database, current_user: User, authorized_client: AsyncClient
+    ):
         members = []
         for x in range(3):
             user = User(wallet_address=f"0x{x}")
             await user.commit()
             members.append(user)
 
-        data = {
-            "kind": "dm",
-            "members": [str(member.id) for member in members]
-        }
+        data = {"kind": "dm", "members": [str(member.id) for member in members]}
 
         response = await authorized_client.post("/channels", json=data)
         assert response.status_code == 201
         json_response = response.json()
         assert json_response != {}
-        assert 'kind' in json_response
-        assert json_response['kind'] == data['kind']
-        assert 'owner' in json_response
-        assert json_response['owner'] == str(current_user.id)
-        assert 'members' in json_response
-        assert all([member in json_response['members'] for member in data['members']])
-        assert str(current_user.id) in json_response['members']
+        assert "kind" in json_response
+        assert json_response["kind"] == data["kind"]
+        assert "owner" in json_response
+        assert json_response["owner"] == str(current_user.id)
+        assert "members" in json_response
+        assert all([member in json_response["members"] for member in data["members"]])
+        assert str(current_user.id) in json_response["members"]
 
     @pytest.mark.asyncio
-    async def test_create_personal_dm_channel(self, app: FastAPI, db: Database, current_user: User,
-                                              authorized_client: AsyncClient):
-        data = {
-            "kind": "dm",
-            "members": []
-        }
+    async def test_create_personal_dm_channel(
+        self, app: FastAPI, db: Database, current_user: User, authorized_client: AsyncClient
+    ):
+        data = {"kind": "dm", "members": []}
 
         response = await authorized_client.post("/channels", json=data)
         assert response.status_code == 201
         json_response = response.json()
         assert json_response != {}
-        assert 'kind' in json_response
-        assert json_response['kind'] == data['kind']
-        assert 'owner' in json_response
-        assert json_response['owner'] == str(current_user.id)
-        assert 'members' in json_response
-        assert str(current_user.id) in json_response['members']
+        assert "kind" in json_response
+        assert json_response["kind"] == data["kind"]
+        assert "owner" in json_response
+        assert json_response["owner"] == str(current_user.id)
+        assert "members" in json_response
+        assert str(current_user.id) in json_response["members"]
 
     @pytest.mark.asyncio
-    async def test_create_multiple_personal_dm_channels(self, app: FastAPI, db: Database, current_user: User,
-                                                        authorized_client: AsyncClient):
-        data = {
-            "kind": "dm",
-            "members": []
-        }
+    async def test_create_multiple_personal_dm_channels(
+        self, app: FastAPI, db: Database, current_user: User, authorized_client: AsyncClient
+    ):
+        data = {"kind": "dm", "members": []}
 
         response = await authorized_client.post("/channels", json=data)
         assert response.status_code == 201
         json_response = response.json()
         assert json_response != {}
-        assert 'kind' in json_response
-        assert json_response['kind'] == data['kind']
-        assert 'owner' in json_response
-        assert json_response['owner'] == str(current_user.id)
-        assert 'members' in json_response
-        assert str(current_user.id) in json_response['members']
-        channel_id = json_response['id']
+        assert "kind" in json_response
+        assert json_response["kind"] == data["kind"]
+        assert "owner" in json_response
+        assert json_response["owner"] == str(current_user.id)
+        assert "members" in json_response
+        assert str(current_user.id) in json_response["members"]
+        channel_id = json_response["id"]
 
         response = await authorized_client.post("/channels", json=data)
         assert response.status_code == 201
         json_response = response.json()
-        assert json_response['id'] == channel_id
+        assert json_response["id"] == channel_id
 
     @pytest.mark.asyncio
-    async def test_create_server_channel(self, app: FastAPI, db: Database, current_user: User, server: Server,
-                                         authorized_client: AsyncClient):
+    async def test_create_server_channel(
+        self, app: FastAPI, db: Database, current_user: User, server: Server, authorized_client: AsyncClient
+    ):
         data = {
             "kind": "server",
             "name": "fancy-announcements",
@@ -92,11 +86,11 @@ class TestChannelsRoutes:
         assert response.status_code == 201
         json_response = response.json()
         assert json_response != {}
-        assert 'kind' in json_response
-        assert json_response['kind'] == data['kind']
-        assert 'owner' in json_response
-        assert json_response['owner'] == str(current_user.id)
-        assert 'name' in json_response
-        assert json_response['name'] == data['name']
-        assert 'server' in json_response
-        assert json_response['server'] == str(server.id)
+        assert "kind" in json_response
+        assert json_response["kind"] == data["kind"]
+        assert "owner" in json_response
+        assert json_response["owner"] == str(current_user.id)
+        assert "name" in json_response
+        assert json_response["name"] == data["name"]
+        assert "server" in json_response
+        assert json_response["server"] == str(server.id)

--- a/app/tests/routers/test_channels.py
+++ b/app/tests/routers/test_channels.py
@@ -94,3 +94,26 @@ class TestChannelsRoutes:
         assert json_response["name"] == data["name"]
         assert "server" in json_response
         assert json_response["server"] == str(server.id)
+
+    @pytest.mark.asyncio
+    async def test_create_server_channel_with_emojis(
+        self, app: FastAPI, db: Database, current_user: User, server: Server, authorized_client: AsyncClient
+    ):
+        data = {
+            "kind": "server",
+            "name": "📣-fancy-announcements",
+            "server": str(server.id),
+        }
+
+        response = await authorized_client.post("/channels", json=data)
+        assert response.status_code == 201
+        json_response = response.json()
+        assert json_response != {}
+        assert "kind" in json_response
+        assert json_response["kind"] == data["kind"]
+        assert "owner" in json_response
+        assert json_response["owner"] == str(current_user.id)
+        assert "name" in json_response
+        assert json_response["name"] == data["name"]
+        assert "server" in json_response
+        assert json_response["server"] == str(server.id)

--- a/app/tests/routers/test_servers.py
+++ b/app/tests/routers/test_servers.py
@@ -4,6 +4,8 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from pymongo.database import Database
 
+from app.models.user import User
+
 
 class TestServerRoutes:
     @pytest.mark.asyncio
@@ -18,7 +20,7 @@ class TestServerRoutes:
         assert response.json() == []
 
     @pytest.mark.asyncio
-    async def test_create_server(self, app: FastAPI, db: Database, authorized_client: AsyncClient):
+    async def test_create_server(self, app: FastAPI, db: Database, current_user: User, authorized_client: AsyncClient):
         server_name = "test"
         response = await authorized_client.post("/servers", json={"name": server_name})
         assert response.status_code == 201
@@ -28,6 +30,8 @@ class TestServerRoutes:
         assert 'id' in json_response
         assert json_response['id'] is not None
         assert json_response['name'] == server_name
+        assert 'owner' in json_response
+        assert json_response['owner'] == str(current_user.id)
 
     @pytest.mark.asyncio
     async def test_create_server_right_objectid_type(self, app: FastAPI, db: Database, authorized_client: AsyncClient):

--- a/app/tests/services/test_crud_service.py
+++ b/app/tests/services/test_crud_service.py
@@ -38,10 +38,11 @@ class TestCRUDService:
     async def test_create_item_custom_user_field(self, db: Database, current_user: User):
         server_name = "Verbs DAO"
         server_model = ServerCreateSchema(name=server_name)
-        created_server = await create_item(item=server_model, result_obj=Server, current_user=current_user,
-                                           user_field='owner')
+        created_server = await create_item(
+            item=server_model, result_obj=Server, current_user=current_user, user_field="owner"
+        )
         assert created_server is not None
         assert created_server.name == server_name
-        assert 'owner' in created_server._fields
+        assert "owner" in created_server._fields
         assert created_server.owner is not None
         assert created_server.owner == current_user

--- a/app/tests/services/test_crud_service.py
+++ b/app/tests/services/test_crud_service.py
@@ -4,7 +4,9 @@ import arrow
 import pytest
 from pymongo.database import Database
 
+from app.models.server import Server
 from app.models.user import User
+from app.schemas.servers import ServerCreateSchema
 from app.schemas.users import UserCreateSchema
 from app.services.crud import create_item
 
@@ -14,7 +16,7 @@ class TestCRUDService:
     async def test_create_user_ok(self, db: Database):
         wallet_address = "0x123"
         model = UserCreateSchema(wallet_address=wallet_address)
-        user = await create_item(item=model, result_obj=User, current_user="")
+        user = await create_item(item=model, result_obj=User, current_user=None, user_field=None)
         assert user is not None
         assert user.wallet_address == wallet_address
 
@@ -22,7 +24,7 @@ class TestCRUDService:
     async def test_create_user_fields_ok(self, db: Database):
         wallet_address = "0x1234"
         model = UserCreateSchema(wallet_address=wallet_address)
-        created_user = await create_item(item=model, result_obj=User, current_user="")
+        created_user = await create_item(item=model, result_obj=User, current_user=None, user_field=None)
         assert created_user is not None
         assert created_user.wallet_address == wallet_address
         assert 'created_at' in created_user._fields
@@ -31,3 +33,15 @@ class TestCRUDService:
         created_date = arrow.get(created_user.created_at)
         assert created_date is not None
         assert (arrow.utcnow() - created_date).seconds <= 2
+
+    @pytest.mark.asyncio
+    async def test_create_item_custom_user_field(self, db: Database, current_user: User):
+        server_name = "Verbs DAO"
+        server_model = ServerCreateSchema(name=server_name)
+        created_server = await create_item(item=server_model, result_obj=Server, current_user=current_user,
+                                           user_field='owner')
+        assert created_server is not None
+        assert created_server.name == server_name
+        assert 'owner' in created_server._fields
+        assert created_server.owner is not None
+        assert created_server.owner == current_user


### PR DESCRIPTION
Added ability to create both DM and Server channels. For the first milestone, no need to list channels or change them so pushing this as a skeleton, but loads of work still needed to get proper CRUD on channels.