### PR TITLE
Fix Server and Channel fetching

### DIFF
--- a/app/models/message.py
+++ b/app/models/message.py
@@ -2,14 +2,14 @@ from umongo import fields
 
 from app.helpers.database import instance
 from app.models.base import APIDocument
-from app.models.channel import ServerChannel
+from app.models.channel import Channel
 from app.models.server import Server
 from app.models.user import User
 
 
 @instance.register
 class Message(APIDocument):
-    channel = fields.ReferenceField(ServerChannel, required=False)
+    channel = fields.ReferenceField(Channel, required=False)
     server = fields.ReferenceField(Server, required=False)
     author = fields.ReferenceField(User, required=True)
 

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -1,13 +1,14 @@
 import http
-from typing import Union
+from typing import List, Union
 
 from fastapi import APIRouter, Body, Depends
 
 from app.dependencies import get_current_user
-from app.helpers.database import get_db
+from app.models.channel import Channel
 from app.models.user import User
 from app.schemas.channels import DMChannelCreateSchema, DMChannelSchema, ServerChannelCreateSchema, ServerChannelSchema
 from app.services.channels import create_channel
+from app.services.crud import get_items
 
 router = APIRouter()
 
@@ -20,7 +21,14 @@ router = APIRouter()
 )
 async def post_create_channel(
     channel: Union[ServerChannelCreateSchema, DMChannelCreateSchema] = Body(...),
-    db=Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     return await create_channel(channel, current_user=current_user)
+
+
+@router.get(
+    "", response_description="List all channels", response_model=List[Union[ServerChannelSchema, DMChannelSchema]]
+)
+async def list_channels(current_user: User = Depends(get_current_user)):
+    channels = await get_items(filters={}, result_obj=Channel, current_user=current_user)
+    return channels

--- a/app/routers/servers.py
+++ b/app/routers/servers.py
@@ -4,11 +4,10 @@ from typing import List
 from fastapi import APIRouter, Body, Depends
 
 from app.dependencies import get_current_user
-from app.helpers.database import get_db
 from app.models.server import Server
 from app.models.user import User
 from app.schemas.servers import ServerCreateSchema, ServerSchema
-from app.services.crud import create_item
+from app.services.crud import create_item, get_items
 
 router = APIRouter()
 
@@ -16,14 +15,12 @@ router = APIRouter()
 @router.post(
     "", response_description="Create new server", response_model=ServerSchema, status_code=http.HTTPStatus.CREATED
 )
-async def post_create_server(
-    server: ServerCreateSchema = Body(...), db=Depends(get_db), current_user: User = Depends(get_current_user)
-):
+async def post_create_server(server: ServerCreateSchema = Body(...), current_user: User = Depends(get_current_user)):
     created_server = await create_item(server, result_obj=Server, current_user=current_user, user_field="owner")
     return created_server
 
 
 @router.get("", response_description="List all servers", response_model=List[ServerSchema])
-async def list_servers(db=Depends(get_db), current_user: User = Depends(get_current_user)):
-    servers = await db["servers"].find().to_list(50)  # TODO: pagination + set default as setting
+async def list_servers(current_user: User = Depends(get_current_user)):
+    servers = await get_items(filters={}, result_obj=Server, current_user=current_user)
     return servers

--- a/app/services/channels.py
+++ b/app/services/channels.py
@@ -3,13 +3,13 @@ from typing import Union
 from bson import ObjectId
 
 from app.models.base import APIDocument
-from app.models.channel import Channel, DMChannel, ServerChannel
+from app.models.channel import Channel
 from app.models.user import User
 from app.schemas.channels import DMChannelCreateSchema, ServerChannelCreateSchema
 from app.services.crud import create_item, get_items
 
 
-async def create_dm_channel(channel_model: DMChannelCreateSchema, current_user: User) -> Union[DMChannel, APIDocument]:
+async def create_dm_channel(channel_model: DMChannelCreateSchema, current_user: User) -> Union[Channel, APIDocument]:
     current_user_id = str(current_user.id)
     if current_user_id not in channel_model.members:
         channel_model.members.insert(0, current_user_id)
@@ -19,18 +19,18 @@ async def create_dm_channel(channel_model: DMChannelCreateSchema, current_user: 
         "owner": current_user.id,
         "members": {"$all": [ObjectId(member) for member in channel_model.members]},
     }
-    existing_dm_channels = await get_items(filters=filters, result_obj=DMChannel, current_user=current_user)
+    existing_dm_channels = await get_items(filters=filters, result_obj=Channel, current_user=current_user)
     if existing_dm_channels:
         # TODO: return 200 status code
         return existing_dm_channels[0]
 
-    return await create_item(channel_model, result_obj=DMChannel, current_user=current_user, user_field="owner")
+    return await create_item(channel_model, result_obj=Channel, current_user=current_user, user_field="owner")
 
 
 async def create_server_channel(
     channel_model: ServerChannelCreateSchema, current_user: User
-) -> Union[ServerChannel, APIDocument]:
-    return await create_item(channel_model, result_obj=ServerChannel, current_user=current_user, user_field="owner")
+) -> Union[Channel, APIDocument]:
+    return await create_item(channel_model, result_obj=Channel, current_user=current_user, user_field="owner")
 
 
 async def create_channel(

--- a/app/tests/routers/test_channels.py
+++ b/app/tests/routers/test_channels.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from pymongo.database import Database
 
+from app.models.channel import Channel
 from app.models.server import Server
 from app.models.user import User
 
@@ -117,3 +118,17 @@ class TestChannelsRoutes:
         assert json_response["name"] == data["name"]
         assert "server" in json_response
         assert json_response["server"] == str(server.id)
+
+    @pytest.mark.asyncio
+    async def test_list_channels_ok(
+        self, app: FastAPI, db: Database, authorized_client: AsyncClient, server: Server, server_channel: Channel
+    ):
+        response = await authorized_client.get("/channels")
+        assert response.status_code == 200
+        json_response = response.json()
+        assert json_response != []
+        assert len(json_response) == 1
+        json_channel = json_response[0]
+        assert json_channel["id"] == str(server_channel.id)
+        assert json_channel["name"] == server_channel.name
+        assert json_channel["server"] == str(server.id)

--- a/app/tests/routers/test_messages.py
+++ b/app/tests/routers/test_messages.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from pymongo.database import Database
 
-from app.models.channel import ServerChannel
+from app.models.channel import Channel
 from app.models.server import Server
 from app.models.user import User
 
@@ -17,7 +17,7 @@ class TestMessagesRoutes:
         current_user: User,
         authorized_client: AsyncClient,
         server: Server,
-        server_channel: ServerChannel,
+        server_channel: Channel,
     ):
         data = {"content": "gm!", "server": str(server.id), "channel": str(server_channel.id)}
         response = await authorized_client.post("/messages", json=data)

--- a/app/tests/routers/test_servers.py
+++ b/app/tests/routers/test_servers.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from pymongo.database import Database
 
+from app.models.server import Server
 from app.models.user import User
 
 
@@ -41,3 +42,14 @@ class TestServerRoutes:
         obj = await db["servers"].find_one()
         assert type(obj["_id"]) != str
         assert type(obj["_id"]) == ObjectId
+
+    @pytest.mark.asyncio
+    async def test_list_servers_ok(self, app: FastAPI, db: Database, authorized_client: AsyncClient, server: Server):
+        response = await authorized_client.get("/servers")
+        assert response.status_code == 200
+        json_response = response.json()
+        assert json_response != []
+        assert len(json_response) == 1
+        json_server = json_response[0]
+        assert json_server["id"] == str(server.id)
+        assert json_server["name"] == server.name


### PR DESCRIPTION
Mostly just getting `GET /servers` and `GET /channels` to work.

Simplified the `Channel` model as well. Different schemas for Server and DM channels still exist, but DB storage model is the same `Channel`.