### PR TITLE
Adding server members

### DIFF
--- a/app/helpers/w3.py
+++ b/app/helpers/w3.py
@@ -23,9 +23,22 @@ def get_wallet_address_from_signed_message(message: str, signature: str) -> str:
 
 
 @cache
-async def get_ens_primary_name_for_address(wallet_address: str) -> str:
+def get_ens_primary_name_for_address(wallet_address: str) -> str:
     settings = get_settings()
     web3_client = Web3(Web3.WebsocketProvider(settings.web3_provider_url_ws))
     wallet_address = checksum_address(wallet_address)
     ens_name = ENS.fromWeb3(web3_client).name(wallet_address)
     return ens_name
+
+
+async def get_wallet_short_name(address: str, check_ens: bool = True) -> str:
+    address = checksum_address(address)
+    short_address = f"{address[:5]}...{address[-3:]}"
+    if check_ens:
+        try:
+            ens_name = get_ens_primary_name_for_address(address)
+            short_address = ens_name or short_address
+        except Exception as e:
+            print(f"problems fetching ENS primary domain for {address}: {e}")
+
+    return short_address

--- a/app/models/server.py
+++ b/app/models/server.py
@@ -1,3 +1,5 @@
+import datetime
+
 from umongo import fields
 
 from app.helpers.database import instance
@@ -13,3 +15,15 @@ class Server(APIDocument):
 
     class Meta:
         collection_name = "servers"
+
+
+@instance.register
+class ServerMember(APIDocument):
+    server = fields.ReferenceField(Server, required=True)
+    user = fields.ReferenceField(User, required=True)
+
+    display_name = fields.StrField()
+    joined_at = fields.DateTimeField(default=datetime.datetime.utcnow)
+
+    class Meta:
+        collection_name = "server_members"

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -6,8 +6,9 @@ from app.models.base import APIDocument
 
 @instance.register
 class User(APIDocument):
+    display_name = fields.StrField()
+
     wallet_address = fields.StrField()
-    ens_name = fields.StrField()
     email = fields.StrField()
 
     online_channels = fields.ListField(fields.StrField(), required=False, default=[])

--- a/app/routers/servers.py
+++ b/app/routers/servers.py
@@ -4,10 +4,9 @@ from typing import List
 from fastapi import APIRouter, Body, Depends
 
 from app.dependencies import get_current_user
-from app.models.server import Server
 from app.models.user import User
-from app.schemas.servers import ServerCreateSchema, ServerSchema
-from app.services.crud import create_item, get_items
+from app.schemas.servers import ServerCreateSchema, ServerMemberSchema, ServerSchema
+from app.services.servers import create_server, get_server_members
 
 router = APIRouter()
 
@@ -16,11 +15,13 @@ router = APIRouter()
     "", response_description="Create new server", response_model=ServerSchema, status_code=http.HTTPStatus.CREATED
 )
 async def post_create_server(server: ServerCreateSchema = Body(...), current_user: User = Depends(get_current_user)):
-    created_server = await create_item(server, result_obj=Server, current_user=current_user, user_field="owner")
-    return created_server
+    return await create_server(server, current_user=current_user)
 
 
-@router.get("", response_description="List all servers", response_model=List[ServerSchema])
-async def list_servers(current_user: User = Depends(get_current_user)):
-    servers = await get_items(filters={}, result_obj=Server, current_user=current_user)
-    return servers
+@router.get(
+    "/{server_id}/members",
+    response_description="List server members",
+    response_model=List[ServerMemberSchema],
+)
+async def get_list_server_members(server_id, current_user: User = Depends(get_current_user)):
+    return await get_server_members(server_id, current_user=current_user)

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,13 +1,24 @@
+from typing import List
+
 from fastapi import APIRouter, Depends
 
 from app.dependencies import get_current_user
-from app.helpers.database import get_db
 from app.models.user import User
+from app.schemas.servers import ServerSchema
 from app.schemas.users import UserSchema
+from app.services.servers import get_user_servers
 
 router = APIRouter()
 
 
 @router.get("/me", response_description="Get user info", response_model=UserSchema, summary="Get current user info")
-async def get_user_me(db=Depends(get_db), current_user: User = Depends(get_current_user)):
+async def get_user_me(current_user: User = Depends(get_current_user)):
     return current_user
+
+
+@router.get(
+    "/me/servers", response_description="List servers current user belongs to", response_model=List[ServerSchema]
+)
+async def list_user_servers(current_user: User = Depends(get_current_user)):
+    servers = await get_user_servers(current_user=current_user)
+    return servers

--- a/app/schemas/servers.py
+++ b/app/schemas/servers.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import Field
 
 from app.schemas.base import APIBaseCreateSchema, APIBaseSchema, PyObjectId
@@ -15,3 +17,22 @@ class ServerSchema(APIBaseSchema):
 
 class ServerCreateSchema(APIBaseCreateSchema):
     name: str
+
+
+class ServerMemberSchema(APIBaseSchema):
+    server: PyObjectId = Field()
+    user: PyObjectId = Field()
+
+    display_name: str = Field()
+    joined_at: datetime
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "id": "61e17018c3ee162141baf5c9",
+                "server": "c3ee162141baf5c1",
+                "user": "c3ee162141baf5c1",
+                "display_name": "fun.eth",
+                "joined_at": "2022-01-01T00:00:00+01:00",
+            }
+        }

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -4,27 +4,29 @@ from app.schemas.base import APIBaseCreateSchema, APIBaseSchema
 
 
 class UserSchema(APIBaseSchema):
+    display_name: Optional[str]
     wallet_address: Optional[str]
-    ens_name: Optional[str]
     email: Optional[str]
 
     class Config:
         schema_extra = {
             "example": {
                 "id": "61e17018c3ee162141baf5c8",
+                "display_name": "vitalik.eth",
                 "wallet_address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
-                "ens_name": "vitalik.eth",
                 "email": "test@newshades.xyz",
             }
         }
 
 
 class UserCreateSchema(APIBaseCreateSchema):
+    display_name: Optional[str] = ""
     wallet_address: str = ""
 
     class Config:
         schema_extra = {
             "example": {
+                "display_name": "vitalik",
                 "wallet_address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
                 "email": "test@newshades.xyz",
             }

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -28,7 +28,7 @@ async def generate_wallet_token(data: dict) -> str:
 
     user = await get_user_by_wallet_address(wallet_address=signed_address)
     if not user:
-        user = await create_user(UserCreateSchema(wallet_address=signed_address))
+        user = await create_user(UserCreateSchema(wallet_address=signed_address), fetch_ens=True)
 
     token = generate_jwt_token({"sub": str(user.id)})
     return token

--- a/app/services/crud.py
+++ b/app/services/crud.py
@@ -1,7 +1,6 @@
-from typing import Optional, Type, Union
+from typing import Optional, Type
 
 from bson import ObjectId
-from umongo.document import DocumentImplementation
 
 from app.models.base import APIDocument
 from app.models.user import User
@@ -25,7 +24,7 @@ async def get_item_by_id(id_: str, result_obj: Type[APIDocument], current_user: 
 
 async def get_items(filters: dict, result_obj: Type[APIDocument], current_user: User) -> [APIDocument]:
     # TODO: add paging default size to settings
-    items = await result_obj.find(filters).to_list(10)
+    items = await result_obj.find(filters).to_list(length=None)
     return items
 
 

--- a/app/services/servers.py
+++ b/app/services/servers.py
@@ -1,0 +1,40 @@
+from typing import Union
+
+from bson import ObjectId
+from fastapi import HTTPException
+from starlette import status
+
+from app.models.base import APIDocument
+from app.models.server import Server, ServerMember
+from app.models.user import User
+from app.schemas.servers import ServerCreateSchema
+from app.services.crud import create_item
+
+
+async def create_server(server_model: ServerCreateSchema, current_user: User) -> Union[Server, APIDocument]:
+    created_server = await create_item(server_model, result_obj=Server, current_user=current_user, user_field="owner")
+
+    # add owner as server member
+    await join_server(created_server, current_user)
+
+    return created_server
+
+
+async def join_server(server: Union[Server, APIDocument], current_user: User, display_name: str = None) -> ServerMember:
+    member = ServerMember(server=server, user=current_user, display_name=display_name or current_user.display_name)
+    await member.commit()
+    return member
+
+
+async def get_user_servers(current_user: User) -> [Server]:
+    server_members = await ServerMember.find({"user": current_user.id}).to_list(length=None)
+    return [await member.server.fetch() for member in server_members]
+
+
+async def get_server_members(server_id: str, current_user: User):
+    user_belongs_to_server = await ServerMember.find_one({"server": ObjectId(server_id), "user": current_user.id})
+    if not user_belongs_to_server:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Missing permissions")
+
+    server_members = await ServerMember.find({"server": ObjectId(server_id)}).to_list(length=None)
+    return server_members

--- a/app/services/users.py
+++ b/app/services/users.py
@@ -1,16 +1,15 @@
 from bson import ObjectId
 
-from app.helpers.w3 import get_ens_primary_name_for_address
+from app.helpers.w3 import get_wallet_short_name
 from app.models.user import User
 from app.schemas.users import UserCreateSchema
 
 
-async def create_user(user_model: UserCreateSchema, expand_ens: bool = False) -> User:
+async def create_user(user_model: UserCreateSchema, fetch_ens: bool = False) -> User:
     user = User(**user_model.dict())
-    if expand_ens:
-        ens_address = await get_ens_primary_name_for_address(user.wallet_address)
-        if ens_address:
-            user.ens_name = ens_address
+    if not user_model.display_name:
+        display_name = await get_wallet_short_name(address=user_model.wallet_address, check_ens=fetch_ens)
+        user.display_name = display_name
     await user.commit()
     return user
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -23,7 +23,7 @@ from app.schemas.servers import ServerCreateSchema
 from app.schemas.users import UserCreateSchema
 from app.services.auth import generate_wallet_token
 from app.services.channels import create_server_channel
-from app.services.crud import create_item
+from app.services.servers import create_server
 from app.services.users import create_user
 
 
@@ -73,7 +73,7 @@ async def current_user(private_key: bytes, wallet: str) -> User:
 @pytest.fixture
 async def server(current_user: User) -> Union[Server, APIDocument]:
     server_model = ServerCreateSchema(name="NewShades DAO")
-    return await create_item(server_model, result_obj=Server, current_user=current_user, user_field="owner")
+    return await create_server(server_model, current_user=current_user)
 
 
 @pytest.fixture

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -67,7 +67,7 @@ def wallet(private_key: bytes) -> str:
 
 @pytest.fixture
 async def current_user(private_key: bytes, wallet: str) -> User:
-    return await create_user(UserCreateSchema(wallet_address=wallet))
+    return await create_user(UserCreateSchema(wallet_address=wallet), fetch_ens=False)
 
 
 @pytest.fixture

--- a/app/tests/routers/test_servers.py
+++ b/app/tests/routers/test_servers.py
@@ -1,25 +1,20 @@
+from datetime import datetime
+
 import pytest
 from bson import ObjectId
 from fastapi import FastAPI
 from httpx import AsyncClient
 from pymongo.database import Database
 
-from app.models.server import Server
+from app.models.server import Server, ServerMember
 from app.models.user import User
+from app.schemas.servers import ServerCreateSchema
+from app.schemas.users import UserCreateSchema
+from app.services.servers import create_server
+from app.services.users import create_user
 
 
 class TestServerRoutes:
-    @pytest.mark.asyncio
-    async def test_list_servers_unauthorized(self, app: FastAPI, db: Database, client: AsyncClient):
-        response = await client.get("/servers")
-        assert response.status_code == 403
-
-    @pytest.mark.asyncio
-    async def test_list_servers_empty(self, app: FastAPI, db: Database, authorized_client: AsyncClient):
-        response = await authorized_client.get("/servers")
-        assert response.status_code == 200
-        assert response.json() == []
-
     @pytest.mark.asyncio
     async def test_create_server(self, app: FastAPI, db: Database, current_user: User, authorized_client: AsyncClient):
         server_name = "test"
@@ -44,12 +39,58 @@ class TestServerRoutes:
         assert type(obj["_id"]) == ObjectId
 
     @pytest.mark.asyncio
-    async def test_list_servers_ok(self, app: FastAPI, db: Database, authorized_client: AsyncClient, server: Server):
-        response = await authorized_client.get("/servers")
+    async def test_create_server_add_member(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+    ):
+        server_name = "test"
+        response = await authorized_client.post("/servers", json={"name": server_name})
+        assert response.status_code == 201
+        json_response = response.json()
+        assert json_response != {}
+        assert "name" in json_response
+        assert "id" in json_response
+        assert json_response["id"] is not None
+        assert json_response["name"] == server_name
+        assert "owner" in json_response
+        assert json_response["owner"] == str(current_user.id)
+
+        members = await ServerMember.find({"server": ObjectId(json_response["id"])}).to_list(length=None)
+        assert len(members) == 1
+        assert members[0].user == current_user
+        assert members[0].joined_at < datetime.utcnow()
+
+    @pytest.mark.asyncio
+    async def test_list_server_members(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+    ):
+        response = await authorized_client.get(f"/servers/{str(server.id)}/members")
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response != []
         assert len(json_response) == 1
-        json_server = json_response[0]
-        assert json_server["id"] == str(server.id)
-        assert json_server["name"] == server.name
+        server_member = json_response[0]
+        assert server_member["server"] == str(server.id)
+        assert server_member["user"] == str(current_user.id)
+
+    @pytest.mark.asyncio
+    async def test_list_server_members_non_member_fail(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+    ):
+        server_model = ServerCreateSchema(name="Private DAO")
+        new_user = await create_user(UserCreateSchema(wallet_address="0x0000000000000000000000000000000000000000"))
+        new_server = await create_server(server_model, current_user=new_user)
+
+        response = await authorized_client.get(f"/servers/{str(new_server.id)}/members")
+        assert response.status_code == 403

--- a/app/tests/routers/test_users.py
+++ b/app/tests/routers/test_users.py
@@ -3,9 +3,33 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from pymongo.database import Database
 
+from app.models.server import Server
+
 
 class TestUserRoutes:
     @pytest.mark.asyncio
     async def test_get_user_me(self, app: FastAPI, db: Database, authorized_client: AsyncClient):
         response = await authorized_client.get("/users/me")
         assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_list_servers_unauthorized(self, app: FastAPI, db: Database, client: AsyncClient):
+        response = await client.get("/users/me/servers")
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_list_servers_empty(self, app: FastAPI, db: Database, authorized_client: AsyncClient):
+        response = await authorized_client.get("/users/me/servers")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @pytest.mark.asyncio
+    async def test_list_servers_ok(self, app: FastAPI, db: Database, authorized_client: AsyncClient, server: Server):
+        response = await authorized_client.get("/users/me/servers")
+        assert response.status_code == 200
+        json_response = response.json()
+        assert json_response != []
+        assert len(json_response) == 1
+        json_server = json_response[0]
+        assert json_server["id"] == str(server.id)
+        assert json_server["name"] == server.name

--- a/app/tests/services/test_users_service.py
+++ b/app/tests/services/test_users_service.py
@@ -1,3 +1,4 @@
+import ens
 import pytest
 
 from app.schemas.users import UserCreateSchema
@@ -6,26 +7,54 @@ from app.services.users import create_user
 
 class TestUsersService:
     @pytest.mark.asyncio
-    async def test_create_user(self, db):
-        wallet_address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+    @pytest.mark.parametrize(
+        "wallet_address, expected_display_name",
+        [
+            ("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "0xd8d...045"),
+            ("0x123A6BF26964aF9D7eEd9e03E53415D37aA96456", "0x123...456"),
+        ],
+    )
+    async def test_create_user(self, db, wallet_address, expected_display_name):
         user_model = UserCreateSchema(wallet_address=wallet_address)
         user = await create_user(user_model=user_model)
-
         assert user is not None
         assert user.wallet_address == wallet_address
-        assert user.ens_name is None
-        assert user.email is None
+        assert user.display_name == expected_display_name
 
-    @pytest.mark.skip
-    async def test_create_user_expand_ens(self, db):
-        wallet_address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "wallet_address, expected_display_name",
+        [
+            ("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "vitalik.eth"),
+            ("0xd8da6bf26964af9d7eed9e03e53415d37aa96045", "vitalik.eth"),
+            ("0x0000000000000000000000000000000000000000", "0x000...000"),
+        ],
+    )
+    async def test_create_user_resolve_ens(self, db, wallet_address, expected_display_name, monkeypatch):
         user_model = UserCreateSchema(wallet_address=wallet_address)
-        user = await create_user(user_model=user_model, expand_ens=True)
 
+        def mock_ens_name(cls, address):
+            if address.lower() == "0xd8da6bf26964af9d7eed9e03e53415d37aa96045":
+                return "vitalik.eth"
+            else:
+                return None
+
+        monkeypatch.setattr(ens.ENS, "name", mock_ens_name)
+
+        user = await create_user(user_model=user_model, fetch_ens=True)
         assert user is not None
         assert user.wallet_address == wallet_address
-        assert user.email is None
-        assert user.ens_name is not None
+        assert user.display_name == expected_display_name
 
-        # TODO: replace all tests and wallet addresses w/ test wallet. This is just for fun
-        assert user.ens_name == "vitalik.eth"
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "wallet_address",
+        [
+            "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96",
+            "0xd8da6bf26964af9d7eed9e03e53415d37aa9604Z",
+        ],
+    )
+    async def test_create_user_invalid_address(self, db, wallet_address):
+        user_model = UserCreateSchema(wallet_address=wallet_address)
+        with pytest.raises(ValueError):
+            await create_user(user_model=user_model)


### PR DESCRIPTION
Creating the concept of ServerMember whenever a user joins a server. The idea is that a user might have specific settings per server: roles, name, etc.

Added a couple of endpoints to handle this new functionality:

- `GET /servers/{server_id}/member`: get list of members in server
- `GET /users/me/servers`: get all servers the current user belongs to (only 1 to start!)

Also set user's `display_name` on sign up to the first of a) ENS domain (if available) or b) shortened address (`0x123...456`). Specific per server `display_name` defaults to current user's