### PR TITLE
Improve websockets

### DIFF
--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,6 +1,6 @@
 import datetime
 
-from umongo import Document, MixinDocument, fields
+from umongo import Document, MixinDocument, Reference, fields
 
 from app.helpers.database import instance
 
@@ -15,5 +15,20 @@ class DatetimeMixin(MixinDocument):
 
 @instance.register
 class APIDocument(Document, DatetimeMixin):
+    async def to_dict(self, expand: bool = False, expand_fields: [str] = None):
+        dumped_obj = self.dump()
+        if not expand:
+            return dumped_obj
+
+        for field, value in self.items():
+            if expand_fields and field not in expand_fields:
+                continue
+
+            if isinstance(value, Reference):
+                value = await value.fetch()
+                dumped_obj[field] = value.dump()
+
+        return dumped_obj
+
     class Meta:
         abstract = True

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -35,4 +35,4 @@ class Channel(APIDocument):
                 raise ValidationError(f"missing fields: {error_fields}")
 
     class Meta:
-        collection = "channels"
+        collection_name = "channels"

--- a/app/routers/webhooks.py
+++ b/app/routers/webhooks.py
@@ -8,17 +8,21 @@ from starlette.background import BackgroundTasks
 from app.helpers.database import get_db
 from app.helpers.websockets import pusher_client
 from app.models.user import User
+from app.services.users import get_user_by_id
+from app.services.websockets import broadcast_connection_ready
 
 router = APIRouter()
 
 
-async def process_webhook_events(events: list[dict], db):
+async def process_webhook_events(events: list[dict]):
     for event in events:
         try:
             channel_name = event["channel"]
             user_id = channel_name.split("-")[1]
             if event["name"] == "channel_occupied":
                 update_data = {"$addToSet": {"online_channels": channel_name}}
+                user = await get_user_by_id(user_id)
+                await broadcast_connection_ready(current_user=user, channel=channel_name)
             elif event["name"] == "channel_vacated":
                 update_data = {"$pull": {"online_channels": channel_name}}
             else:
@@ -52,6 +56,6 @@ async def post_pusher_webhooks(
     if not webhook:
         raise webhook_exception
 
-    background_tasks.add_task(process_webhook_events, events=webhook["events"], db=db)
+    background_tasks.add_task(process_webhook_events, events=webhook["events"])
 
     return {"received": "ok"}

--- a/app/services/channels.py
+++ b/app/services/channels.py
@@ -43,3 +43,7 @@ async def create_channel(
         return await create_server_channel(channel_model, current_user)
     else:
         raise Exception(f"unexpected channel kind: {kind}")
+
+
+async def get_server_channels(server_id, current_user: User) -> [Channel]:
+    return await get_items(filters={"server": ObjectId(server_id)}, result_obj=Channel, current_user=current_user)

--- a/app/services/messages.py
+++ b/app/services/messages.py
@@ -15,8 +15,6 @@ async def create_message(
 ) -> Union[Message, APIDocument]:
     message = await create_item(item=message_model, result_obj=Message, current_user=current_user, user_field="author")
 
-    background_tasks.add_task(
-        broadcast_new_message, message_model=message_model, message=message, current_user=current_user
-    )
+    background_tasks.add_task(broadcast_new_message, message=message, current_user=current_user)
 
     return message

--- a/app/services/websockets.py
+++ b/app/services/websockets.py
@@ -1,0 +1,69 @@
+from app.helpers.websockets import pusher_client
+from app.models.message import Message
+from app.models.server import Server, ServerMember
+from app.models.user import User
+from app.schemas.messages import MessageCreateSchema
+from app.services.channels import get_server_channels
+from app.services.crud import get_item, get_items
+from app.services.servers import get_server_members, get_user_servers
+
+
+async def get_online_channels(message: Message, current_user: User) -> [str]:
+    server = message.server  # type: Server
+    server_members = await get_items(filters={"server": server.pk}, result_obj=ServerMember, current_user=current_user)
+    server_users = [await member.user.fetch() for member in server_members]
+    channels = []
+    for user in server_users:  # type: User
+        channels.extend(user.online_channels)
+    return channels
+
+
+async def pusher_broadcast_messages(channels: [str], event_name: str, data: dict):
+    while len(channels) > 0:
+        push_channels = channels[:90]
+        try:
+            await pusher_client.trigger(push_channels, event_name, data)
+        except Exception as e:
+            print(f"problems triggering Pusher events: {e}")
+        channels = channels[90:]
+
+
+async def broadcast_new_message(
+    message_model: MessageCreateSchema,
+    message: Message,
+    current_user: User,
+):
+    event_name = "MESSAGE_CREATE"
+    ws_data = {**message_model.dict(), "author": str(current_user.id)}
+    channels = await get_online_channels(message, current_user)
+
+    await pusher_broadcast_messages(channels, event_name=event_name, data=ws_data)
+
+
+async def broadcast_connection_ready(current_user: User, channel: str):
+    event_name = "CONNECTION_READY"
+    data = {"user": current_user.dump(), "servers": []}
+
+    servers = await get_user_servers(current_user=current_user)
+    for server in servers:
+        server_data = server.dump()
+        channels = await get_server_channels(server_id=str(server.id), current_user=current_user)
+        members = await get_server_members(server_id=str(server.id), current_user=current_user)
+        user_member = await get_item(
+            filters={"server": server.id, "user": current_user.id},
+            result_obj=ServerMember,
+            current_user=current_user,
+        )
+
+        server_data.update(
+            {
+                "channels": [channel.dump() for channel in channels],
+                "members": [member.dump() for member in members],
+                "member": user_member.dump() if user_member else {},
+            }
+        )
+
+        data["servers"].append(server_data)
+
+    push_channels = [channel]
+    await pusher_broadcast_messages(push_channels, event_name, data)

--- a/app/services/websockets.py
+++ b/app/services/websockets.py
@@ -2,7 +2,6 @@ from app.helpers.websockets import pusher_client
 from app.models.message import Message
 from app.models.server import Server, ServerMember
 from app.models.user import User
-from app.schemas.messages import MessageCreateSchema
 from app.services.channels import get_server_channels
 from app.services.crud import get_item, get_items
 from app.services.servers import get_server_members, get_user_servers
@@ -29,12 +28,11 @@ async def pusher_broadcast_messages(channels: [str], event_name: str, data: dict
 
 
 async def broadcast_new_message(
-    message_model: MessageCreateSchema,
     message: Message,
     current_user: User,
 ):
     event_name = "MESSAGE_CREATE"
-    ws_data = {**message_model.dict(), "author": str(current_user.id)}
+    ws_data = message.dump()
     channels = await get_online_channels(message, current_user)
 
     await pusher_broadcast_messages(channels, event_name=event_name, data=ws_data)


### PR DESCRIPTION

- New 'CONNECTION_READY' event for clients to not have to do a few API requests to get data about the user and their servers/channels.
- Split websocket specific logic into its own service
- Added `to_dict()` method to base mongo docs. Not using rn, but might start using it if clients need more data on each socket message.
