### PR TITLE
Delete channels

### DIFF
--- a/app/models/base.py
+++ b/app/models/base.py
@@ -15,6 +15,8 @@ class DatetimeMixin(MixinDocument):
 
 @instance.register
 class APIDocument(Document, DatetimeMixin):
+    deleted = fields.BoolField(default=False)
+
     async def to_dict(self, expand: bool = False, expand_fields: [str] = None):
         dumped_obj = self.dump()
         if not expand:

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -8,7 +8,7 @@ from app.models.channel import Channel
 from app.models.user import User
 from app.schemas.channels import DMChannelCreateSchema, DMChannelSchema, ServerChannelCreateSchema, ServerChannelSchema
 from app.schemas.messages import MessageSchema
-from app.services.channels import create_channel
+from app.services.channels import create_channel, delete_channel
 from app.services.crud import get_items
 from app.services.messages import get_messages
 
@@ -40,3 +40,11 @@ async def list_channels(current_user: User = Depends(get_current_user)):
 async def get_list_messages(channel_id, size: int = 50, current_user: User = Depends(get_current_user)):
     messages = await get_messages(channel_id, size, current_user=current_user)
     return messages
+
+
+@router.delete(
+    "/{channel_id}", response_description="Delete channel", response_model=Union[ServerChannelSchema, DMChannelSchema]
+)
+async def delete_remove_channel(channel_id, current_user: User = Depends(get_current_user)):
+    channel = await delete_channel(channel_id=channel_id, current_user=current_user)
+    return channel

--- a/app/schemas/base.py
+++ b/app/schemas/base.py
@@ -27,6 +27,7 @@ class APIBaseSchema(BaseModel):
     id: PyObjectId = Field()
     created_at: datetime
     updated_at: datetime = None  # TODO: fix this in umongo doc
+    deleted: bool = False
 
     class Config:
         orm_mode = True

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -7,13 +7,14 @@ from app.helpers.jwt import generate_jwt_token
 from app.helpers.w3 import checksum_address, get_wallet_address_from_signed_message
 from app.models.server import Server
 from app.schemas.users import UserCreateSchema
+from app.services.crud import get_items
 from app.services.servers import join_server
 from app.services.users import create_user, get_user_by_id, get_user_by_wallet_address
 
 
 async def add_user_to_default_server(user_id):
     user = await get_user_by_id(user_id=user_id)
-    servers = await Server.find({}).sort("created_at", 1).to_list(1)
+    servers = await get_items(filters={}, result_obj=Server, current_user=user, size=1, sort_by_direction=1)
     server = servers[0]
     await join_server(server=server, current_user=user)
 

--- a/app/services/channels.py
+++ b/app/services/channels.py
@@ -6,7 +6,7 @@ from app.models.base import APIDocument
 from app.models.channel import Channel
 from app.models.user import User
 from app.schemas.channels import DMChannelCreateSchema, ServerChannelCreateSchema
-from app.services.crud import create_item, get_items
+from app.services.crud import create_item, delete_item, get_item_by_id, get_items
 
 
 async def create_dm_channel(channel_model: DMChannelCreateSchema, current_user: User) -> Union[Channel, APIDocument]:
@@ -47,3 +47,15 @@ async def create_channel(
 
 async def get_server_channels(server_id, current_user: User) -> [Channel]:
     return await get_items(filters={"server": ObjectId(server_id)}, result_obj=Channel, current_user=current_user)
+
+
+async def delete_channel(channel_id, current_user: User):
+    channel = await get_item_by_id(id_=channel_id, result_obj=Channel, current_user=current_user)
+    channel_owner = channel.owner
+    server = await channel.server.fetch()
+    server_owner = server.owner
+
+    if not current_user == channel_owner or not current_user == server_owner:
+        raise Exception("user can't delete channel")
+
+    return await delete_item(item=channel)

--- a/app/services/channels.py
+++ b/app/services/channels.py
@@ -1,6 +1,8 @@
+import http
 from typing import Union
 
 from bson import ObjectId
+from fastapi import HTTPException
 
 from app.models.base import APIDocument
 from app.models.channel import Channel
@@ -56,6 +58,6 @@ async def delete_channel(channel_id, current_user: User):
     server_owner = server.owner
 
     if not current_user == channel_owner or not current_user == server_owner:
-        raise Exception("user can't delete channel")
+        raise HTTPException(status_code=http.HTTPStatus.FORBIDDEN)
 
     return await delete_item(item=channel)

--- a/app/services/crud.py
+++ b/app/services/crud.py
@@ -21,20 +21,32 @@ async def create_item(
     return db_object
 
 
-async def get_item_by_id(id_: str, result_obj: Type[APIDocument], current_user: User) -> APIDocument:
+async def get_item_by_id(id_: str, result_obj: Type[APIDocument], current_user: Optional[User] = None) -> APIDocument:
     item = await result_obj.find_one({"_id": ObjectId(id_)})
     return item
 
 
 async def get_items(
-    filters: dict, result_obj: Type[APIDocument], current_user: User, size: Optional[int] = None
+    filters: dict,
+    result_obj: Type[APIDocument],
+    current_user: User,
+    size: Optional[int] = None,
+    sort_by_field: str = "created_at",
+    sort_by_direction: int = -1,
 ) -> [APIDocument]:
     # TODO: add paging default size to settings
-    items = await result_obj.find(filters).sort("created_at", -1).to_list(length=size)
+
+    deleted_filter = {"$or": [{"deleted": {"$exists": False}}, {"deleted": False}]}
+    filters.update(deleted_filter)
+
+    items = await result_obj.find(filters).sort(sort_by_field, sort_by_direction).to_list(length=size)
     return items
 
 
-async def get_item(filters: dict, result_obj: Type[APIDocument], current_user: User) -> APIDocument:
+async def get_item(filters: dict, result_obj: Type[APIDocument], current_user: Optional[User] = None) -> APIDocument:
+    deleted_filter = {"$or": [{"deleted": {"$exists": False}}, {"deleted": False}]}
+    filters.update(deleted_filter)
+
     item = await result_obj.find_one(filters)
     return item
 

--- a/app/services/crud.py
+++ b/app/services/crud.py
@@ -37,3 +37,13 @@ async def get_items(
 async def get_item(filters: dict, result_obj: Type[APIDocument], current_user: User) -> APIDocument:
     item = await result_obj.find_one(filters)
     return item
+
+
+async def update_item(item: APIDocument, data: dict) -> APIDocument:
+    item.update(data)
+    await item.commit()
+    return item
+
+
+async def delete_item(item: APIDocument) -> APIDocument:
+    return await update_item(item, {"deleted": True})

--- a/app/services/users.py
+++ b/app/services/users.py
@@ -1,8 +1,12 @@
+from typing import Union
+
 from bson import ObjectId
 
 from app.helpers.w3 import get_wallet_short_name
+from app.models.base import APIDocument
 from app.models.user import User
 from app.schemas.users import UserCreateSchema
+from app.services.crud import get_item, get_item_by_id
 
 
 async def create_user(user_model: UserCreateSchema, fetch_ens: bool = False) -> User:
@@ -14,17 +18,17 @@ async def create_user(user_model: UserCreateSchema, fetch_ens: bool = False) -> 
     return user
 
 
-async def get_user_by_wallet_address(wallet_address: str) -> User:
-    user = await User.find_one({"wallet_address": wallet_address})
+async def get_user_by_wallet_address(wallet_address: str) -> Union[User, APIDocument]:
+    user = await get_item(filters={"wallet_address": wallet_address}, result_obj=User)
     return user
 
 
-async def get_user_by_id(user_id) -> User:
-    if isinstance(user_id, str):
-        user_id = ObjectId(user_id)
-    elif isinstance(user_id, ObjectId):
+async def get_user_by_id(user_id) -> Union[User, APIDocument]:
+    if isinstance(user_id, ObjectId):
+        user_id = str(user_id)
+    elif isinstance(user_id, str):
         pass
     else:
         raise Exception(f"unexpected user_id type: {type(user_id)}")
 
-    return await User.find_one({"_id": user_id})
+    return await get_item_by_id(id_=user_id, result_obj=User)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -69,6 +69,15 @@ async def current_user(private_key: bytes, wallet: str) -> User:
 
 
 @pytest.fixture
+async def guest_user() -> User:
+    key = secrets.token_bytes(32)
+    priv = binascii.hexlify(key).decode("ascii")
+    private_key = "0x" + priv
+    acct = Account.from_key(private_key)
+    return await create_user(UserCreateSchema(wallet_address=acct.address), fetch_ens=False)
+
+
+@pytest.fixture
 async def server(current_user: User) -> Union[Server, APIDocument]:
     server_model = ServerCreateSchema(name="NewShades DAO")
     return await create_server(server_model, current_user=current_user)

--- a/app/tests/routers/test_websockets.py
+++ b/app/tests/routers/test_websockets.py
@@ -8,7 +8,7 @@ from app.models.message import Message
 from app.models.server import Server, ServerMember
 from app.models.user import User
 from app.schemas.messages import MessageCreateSchema
-from app.services.crud import create_item
+from app.services.crud import create_item, get_items
 from app.services.websockets import get_online_channels
 
 
@@ -68,7 +68,7 @@ class TestWebsocketRoutes:
             item=message_model, result_obj=Message, current_user=current_user, user_field="author"
         )
 
-        members = await ServerMember.find().to_list(None)
+        members = await get_items(filters={}, result_obj=ServerMember, current_user=current_user, size=None)
         assert len(members) == 1
         member = members[0]
         assert member.server == server

--- a/app/tests/services/test_auth_service.py
+++ b/app/tests/services/test_auth_service.py
@@ -2,13 +2,12 @@ import json
 
 import arrow
 import pytest
-from bson import ObjectId
 from eth_account.messages import encode_defunct
 from web3 import Web3
 
 from app.helpers.jwt import decode_jwt_token
-from app.models.user import User
 from app.services.auth import generate_wallet_token
+from app.services.users import get_user_by_id
 
 
 class TestAuthService:
@@ -26,6 +25,6 @@ class TestAuthService:
         token_user_id = decrypted_token.get("sub")
         assert token_user_id != wallet
 
-        user = await User.find_one({"_id": ObjectId(token_user_id)})
+        user = await get_user_by_id(user_id=token_user_id)
         assert user is not None
         assert user.wallet_address == wallet


### PR DESCRIPTION
Added the ability to delete channels: `DELETE /channels/{channel_id}`

With that change, also changed the following:
- Added `deleted` field to all objects to allow soft deletion across the platform. Might have to consider hard deletion for wallet-related stuff.
- Updated all interactions w/ DB to go through `crud.py` service. Minimize risks in terms of security (e.g. having one-off DB calls without permission checking) and consistency.