### PR TITLE
Add emoji reactions

### DIFF
--- a/app/models/message.py
+++ b/app/models/message.py
@@ -1,4 +1,4 @@
-from umongo import fields
+from umongo import EmbeddedDocument, fields
 
 from app.helpers.db_utils import instance
 from app.models.base import APIDocument
@@ -8,12 +8,21 @@ from app.models.user import User
 
 
 @instance.register
+class MessageReaction(EmbeddedDocument):
+    emoji = fields.StrField(required=True)
+    count = fields.IntField(default=1)
+    users = fields.ListField(fields.ReferenceField(User))
+
+
+@instance.register
 class Message(APIDocument):
     channel = fields.ReferenceField(Channel, required=False)
     server = fields.ReferenceField(Server, required=False)
     author = fields.ReferenceField(User, required=True)
 
     content = fields.StrField()  # TODO: prolly not only a string
+
+    reactions = fields.ListField(fields.EmbeddedField(MessageReaction), default=[])
 
     class Meta:
         collection_name = "messages"

--- a/app/routers/messages.py
+++ b/app/routers/messages.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Body, Depends
 from app.dependencies import get_current_user
 from app.models.user import User
 from app.schemas.messages import MessageCreateSchema, MessageReactionCreateSchema, MessageSchema
-from app.services.messages import add_reaction_to_message, create_message
+from app.services.messages import add_reaction_to_message, create_message, remove_reaction_from_message
 
 router = APIRouter()
 
@@ -34,3 +34,16 @@ async def post_add_reaction(
     current_user: User = Depends(get_current_user),
 ):
     await add_reaction_to_message(message_id, reaction_model=reaction, current_user=current_user)
+
+
+@router.delete(
+    "/{message_id}/reactions/{reaction_emoji}",
+    summary="Remove reaction to message",
+    status_code=http.HTTPStatus.NO_CONTENT,
+)
+async def delete_remove_reaction(
+    message_id: str,
+    reaction_emoji: str,
+    current_user: User = Depends(get_current_user),
+):
+    await remove_reaction_from_message(message_id, reaction_emoji, current_user=current_user)

--- a/app/routers/messages.py
+++ b/app/routers/messages.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter, Body, Depends
 
 from app.dependencies import get_current_user
 from app.models.user import User
-from app.schemas.messages import MessageCreateSchema, MessageSchema
-from app.services.messages import create_message
+from app.schemas.messages import MessageCreateSchema, MessageReactionCreateSchema, MessageSchema
+from app.services.messages import add_reaction_to_message, create_message
 
 router = APIRouter()
 
@@ -21,3 +21,16 @@ async def post_create_message(
     current_user: User = Depends(get_current_user),
 ):
     return await create_message(message, current_user=current_user)
+
+
+@router.post(
+    "/{message_id}/reactions",
+    summary="Add reaction to message",
+    status_code=http.HTTPStatus.NO_CONTENT,
+)
+async def post_add_reaction(
+    message_id: str,
+    reaction: MessageReactionCreateSchema = Body(...),
+    current_user: User = Depends(get_current_user),
+):
+    await add_reaction_to_message(message_id, reaction_model=reaction, current_user=current_user)

--- a/app/routers/messages.py
+++ b/app/routers/messages.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Body, Depends
 
 from app.dependencies import get_current_user
 from app.models.user import User
-from app.schemas.messages import MessageCreateSchema, MessageReactionCreateSchema, MessageSchema
+from app.schemas.messages import MessageCreateSchema, MessageSchema
 from app.services.messages import add_reaction_to_message, create_message, remove_reaction_from_message
 
 router = APIRouter()
@@ -24,16 +24,16 @@ async def post_create_message(
 
 
 @router.post(
-    "/{message_id}/reactions",
+    "/{message_id}/reactions/{reaction_emoji}",
     summary="Add reaction to message",
     status_code=http.HTTPStatus.NO_CONTENT,
 )
 async def post_add_reaction(
     message_id: str,
-    reaction: MessageReactionCreateSchema = Body(...),
+    reaction_emoji: str,
     current_user: User = Depends(get_current_user),
 ):
-    await add_reaction_to_message(message_id, reaction_model=reaction, current_user=current_user)
+    await add_reaction_to_message(message_id, reaction_emoji=reaction_emoji, current_user=current_user)
 
 
 @router.delete(

--- a/app/schemas/messages.py
+++ b/app/schemas/messages.py
@@ -16,10 +16,6 @@ class MessageReactionSchema(BaseModel):
         arbitrary_types_allowed = True
 
 
-class MessageReactionCreateSchema(APIBaseCreateSchema):
-    emoji: str
-
-
 class MessageSchema(APIBaseSchema):
     author: PyObjectId = Field()
     server: PyObjectId = Field()

--- a/app/schemas/messages.py
+++ b/app/schemas/messages.py
@@ -1,6 +1,23 @@
-from pydantic import Field
+from typing import List
+
+from pydantic import BaseModel, Field
 
 from app.schemas.base import APIBaseCreateSchema, APIBaseSchema, PyObjectId
+
+
+class MessageReactionSchema(BaseModel):
+    emoji: str
+    users: List[PyObjectId]
+    count: int
+
+    class Config:
+        orm_mode = True
+        allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+
+
+class MessageReactionCreateSchema(APIBaseCreateSchema):
+    emoji: str
 
 
 class MessageSchema(APIBaseSchema):
@@ -8,6 +25,7 @@ class MessageSchema(APIBaseSchema):
     server: PyObjectId = Field()
     channel: PyObjectId = Field()
     content: str
+    reactions: List[MessageReactionSchema]
 
 
 class MessageCreateSchema(APIBaseCreateSchema):

--- a/app/services/messages.py
+++ b/app/services/messages.py
@@ -5,7 +5,7 @@ from app.models.base import APIDocument
 from app.models.channel import Channel
 from app.models.message import Message, MessageReaction
 from app.models.user import User
-from app.schemas.messages import MessageCreateSchema, MessageReactionCreateSchema
+from app.schemas.messages import MessageCreateSchema
 from app.services.crud import create_item, get_item_by_id, get_items
 from app.services.websockets import broadcast_new_message, broadcast_new_reaction, broadcast_remove_reaction
 
@@ -29,12 +29,12 @@ async def get_messages(channel_id: str, size: int, current_user: User) -> List[M
     return messages
 
 
-async def add_reaction_to_message(message_id, reaction_model: MessageReactionCreateSchema, current_user: User):
+async def add_reaction_to_message(message_id, reaction_emoji: str, current_user: User):
     message = await get_item_by_id(
         id_=message_id, result_obj=Message, current_user=current_user
     )  # type: Union[Message, APIDocument]
 
-    reaction = MessageReaction(**reaction_model.dict(), count=1, users=[current_user])
+    reaction = MessageReaction(emoji=reaction_emoji, count=1, users=[current_user])
     existing_reactions = message.reactions
 
     found = False

--- a/app/services/websockets.py
+++ b/app/services/websockets.py
@@ -74,3 +74,21 @@ async def broadcast_connection_ready(current_user: User, channel: str):
 
     push_channels = [channel]
     await pusher_broadcast_messages(push_channels, event_name, data)
+
+
+async def broadcast_new_reaction(message_id, reaction, author_id):
+    user = await get_user_by_id(user_id=author_id)
+    message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=user)
+    event_name = "MESSAGE_REACTION_ADD"
+    ws_data = {"message": message_id, "user": user.dump(), "reaction": reaction.dump()}
+    channels = await get_online_channels(message=message, current_user=user)
+    await pusher_broadcast_messages(channels, event_name=event_name, data=ws_data)
+
+
+async def broadcast_remove_reaction(message_id, reaction, author_id):
+    user = await get_user_by_id(user_id=author_id)
+    message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=user)
+    event_name = "MESSAGE_REACTION_REMOVE"
+    ws_data = {"message": message_id, "user": user.dump(), "reaction": reaction.dump()}
+    channels = await get_online_channels(message=message, current_user=user)
+    await pusher_broadcast_messages(channels, event_name=event_name, data=ws_data)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -19,10 +19,12 @@ from app.models.channel import Channel
 from app.models.server import Server
 from app.models.user import User
 from app.schemas.channels import ServerChannelCreateSchema
+from app.schemas.messages import MessageCreateSchema
 from app.schemas.servers import ServerCreateSchema
 from app.schemas.users import UserCreateSchema
 from app.services.auth import generate_wallet_token
 from app.services.channels import create_server_channel
+from app.services.messages import create_message
 from app.services.servers import create_server
 from app.services.users import create_user
 
@@ -87,6 +89,12 @@ async def server(current_user: User) -> Union[Server, APIDocument]:
 async def server_channel(current_user: User, server: Server) -> Union[Channel, APIDocument]:
     server_channel = ServerChannelCreateSchema(kind="server", server=str(server.id), name="testing-channel")
     return await create_server_channel(server_channel, current_user=current_user)
+
+
+@pytest.fixture
+async def channel_message(current_user: User, server: Server, server_channel: Channel):
+    message = MessageCreateSchema(server=str(server.id), channel=str(server_channel.id), content="hey")
+    return await create_message(message, current_user=current_user)
 
 
 @pytest.fixture

--- a/app/tests/routers/test_messages.py
+++ b/app/tests/routers/test_messages.py
@@ -4,8 +4,11 @@ from httpx import AsyncClient
 from pymongo.database import Database
 
 from app.models.channel import Channel
+from app.models.message import Message, MessageReaction
 from app.models.server import Server
 from app.models.user import User
+from app.services.crud import get_item_by_id
+from app.services.messages import get_messages
 
 
 class TestMessagesRoutes:
@@ -28,3 +31,134 @@ class TestMessagesRoutes:
         assert json_response["content"] == data["content"]
         assert json_response["server"] == data["server"] == str(server.id)
         assert json_response["channel"] == data["channel"] == str(server_channel.id)
+
+    @pytest.mark.asyncio
+    async def test_add_reaction_to_message(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+        channel_message: Message,
+    ):
+        messages = await get_messages(channel_id=str(server_channel.id), current_user=current_user, size=100)
+        assert len(messages) == 1
+
+        message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
+        assert message == channel_message
+        assert len(message.reactions) == 0
+
+        reaction_data = {"emoji": "🙌"}
+        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions", json=reaction_data)
+        assert response.status_code == 204
+
+        message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
+        assert len(message.reactions) == 1
+        reaction = message.reactions[0]
+        assert reaction.emoji == reaction_data["emoji"]
+        assert reaction.count == 1
+        assert [user.pk for user in reaction.users] == [current_user.id]
+
+    @pytest.mark.asyncio
+    async def test_add_same_reaction_to_message(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+        channel_message: Message,
+        guest_user: User,
+    ):
+        channel_message.reactions.append(MessageReaction(emoji="😍", count=1, users=[guest_user.pk]))
+        await channel_message.commit()
+
+        message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
+        assert message == channel_message
+        assert len(message.reactions) == 1
+
+        reaction_data = {"emoji": "😍"}
+        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions", json=reaction_data)
+        assert response.status_code == 204
+
+        message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
+        assert len(message.reactions) == 1
+        reaction = message.reactions[0]
+        assert reaction.emoji == reaction_data["emoji"]
+        assert reaction.count == 2
+        assert [user.pk for user in reaction.users] == [guest_user.id, current_user.id]
+
+    @pytest.mark.asyncio
+    async def test_add_same_user_reaction_to_message(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+        channel_message: Message,
+        guest_user: User,
+    ):
+        channel_message.reactions = [MessageReaction(emoji="😍", count=1, users=[current_user.pk])]
+        await channel_message.commit()
+
+        message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
+        assert message == channel_message
+        assert len(message.reactions) == 1
+
+        reaction_data = {"emoji": "😍"}
+        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions", json=reaction_data)
+        assert response.status_code == 204
+
+        message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
+        assert len(message.reactions) == 1
+        reaction = message.reactions[0]
+        assert reaction.emoji == reaction_data["emoji"]
+        assert reaction.count == 1
+        assert [user.pk for user in reaction.users] == [current_user.id]
+
+    @pytest.mark.asyncio
+    async def test_add_new_reaction_to_message_with_reactions(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+        channel_message: Message,
+        guest_user: User,
+    ):
+        channel_message.reactions = [MessageReaction(emoji="😍", count=1, users=[guest_user.pk])]
+        await channel_message.commit()
+
+        message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
+        assert message == channel_message
+        assert len(message.reactions) == 1
+
+        reaction_data = {"emoji": "💪"}
+        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions", json=reaction_data)
+        assert response.status_code == 204
+
+        message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
+        assert len(message.reactions) == 2
+        first_reaction = message.reactions[0]
+        assert first_reaction.emoji == "😍"
+        assert first_reaction.count == 1
+        assert [user.pk for user in first_reaction.users] == [guest_user.id]
+
+        second_reaction = message.reactions[1]
+        assert second_reaction.emoji == reaction_data["emoji"]
+        assert second_reaction.count == 1
+        assert [user.pk for user in second_reaction.users] == [current_user.id]
+
+        response = await authorized_client.get(f"/channels/{str(server_channel.id)}/messages")
+        assert response.status_code == 200
+        json_response = response.json()
+        json_message = json_response[0]
+        assert "reactions" in json_message
+        assert len(json_message["reactions"]) == 2

--- a/app/tests/routers/test_messages.py
+++ b/app/tests/routers/test_messages.py
@@ -50,14 +50,13 @@ class TestMessagesRoutes:
         assert message == channel_message
         assert len(message.reactions) == 0
 
-        reaction_data = {"emoji": "🙌"}
-        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions", json=reaction_data)
+        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions/🙌")
         assert response.status_code == 204
 
         message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
         assert len(message.reactions) == 1
         reaction = message.reactions[0]
-        assert reaction.emoji == reaction_data["emoji"]
+        assert reaction.emoji == "🙌"
         assert reaction.count == 1
         assert [user.pk for user in reaction.users] == [current_user.id]
 
@@ -73,21 +72,21 @@ class TestMessagesRoutes:
         channel_message: Message,
         guest_user: User,
     ):
-        channel_message.reactions = [MessageReaction(emoji="😍", count=1, users=[guest_user.pk])]
+        emoji = "😍"
+        channel_message.reactions = [MessageReaction(emoji=emoji, count=1, users=[guest_user.pk])]
         await channel_message.commit()
 
         message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
         assert message == channel_message
         assert len(message.reactions) == 1
 
-        reaction_data = {"emoji": "😍"}
-        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions", json=reaction_data)
+        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions/{emoji}")
         assert response.status_code == 204
 
         message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
         assert len(message.reactions) == 1
         reaction = message.reactions[0]
-        assert reaction.emoji == reaction_data["emoji"]
+        assert reaction.emoji == emoji
         assert reaction.count == 2
         assert [user.pk for user in reaction.users] == [guest_user.id, current_user.id]
 
@@ -103,21 +102,21 @@ class TestMessagesRoutes:
         channel_message: Message,
         guest_user: User,
     ):
-        channel_message.reactions = [MessageReaction(emoji="😍", count=1, users=[current_user.pk])]
+        emoji = "😍"
+        channel_message.reactions = [MessageReaction(emoji=emoji, count=1, users=[current_user.pk])]
         await channel_message.commit()
 
         message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
         assert message == channel_message
         assert len(message.reactions) == 1
 
-        reaction_data = {"emoji": "😍"}
-        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions", json=reaction_data)
+        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions/{emoji}")
         assert response.status_code == 204
 
         message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
         assert len(message.reactions) == 1
         reaction = message.reactions[0]
-        assert reaction.emoji == reaction_data["emoji"]
+        assert reaction.emoji == emoji
         assert reaction.count == 1
         assert [user.pk for user in reaction.users] == [current_user.id]
 
@@ -140,8 +139,8 @@ class TestMessagesRoutes:
         assert message == channel_message
         assert len(message.reactions) == 1
 
-        reaction_data = {"emoji": "💪"}
-        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions", json=reaction_data)
+        new_emoji = "💪"
+        response = await authorized_client.post(f"/messages/{str(message.id)}/reactions/{new_emoji}")
         assert response.status_code == 204
 
         message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
@@ -152,7 +151,7 @@ class TestMessagesRoutes:
         assert [user.pk for user in first_reaction.users] == [guest_user.id]
 
         second_reaction = message.reactions[1]
-        assert second_reaction.emoji == reaction_data["emoji"]
+        assert second_reaction.emoji == new_emoji
         assert second_reaction.count == 1
         assert [user.pk for user in second_reaction.users] == [current_user.id]
 


### PR DESCRIPTION
Be able to add emoji reactions to messages. Kept 'emoji' as the default reaction, but potentially we could have more structured reactions later on (e.g. voting).

- `POST /messages/{message_id}/reactions/🔥`
- `DELETE /messages/{message_id}/reactions/🔥`
