### PR TITLE
use user-friendly signing rather than json

### DIFF
--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,27 +1,22 @@
-from typing import Optional
-
 from pydantic import BaseModel, Field
 
 
-class WalletMessageSchema(BaseModel):
-    address: Optional[str] = None
-    signed_at: Optional[str] = None
-
-
 class AuthWalletSchema(BaseModel):
-    message: WalletMessageSchema = Field()
+    message: str = Field()
     signature: str = Field()
+    address: str = Field()
+    signed_at: str = Field()
+    nonce: int = Field()
 
     class Config:
         allow_population_by_field_name = True
-        json_encoders = {WalletMessageSchema: dict}
         schema_extra = {
             "example": {
-                "message": {
-                    "address": "0x1231237072081028432784128371234898237233",
-                    "signed_at": "2022-01-01T12:12:12.123Z",
-                },
-                "signature": "0x1231237072081028432784128371234898237233479",
+                "message": "NewShades wants you to sign in with your web3 account\n0x1231237072081028432784128371234898237233...",
+                "signature": "0x04cc5c3082e888cb28e99b78e7eb7b75a2fed2000083026683643e65356304d166eb0c27d69c9bccdfc6bf9f44c334b67320a4d306884ba13996995a0f103fe14",
+                "address": "0x1231237072081028432784128371234898237233",
+                "signed_at": "2022-01-01T12:12:12.123Z",
+                "nonce": 123123,
             }
         }
 

--- a/app/tests/routers/test_auth.py
+++ b/app/tests/routers/test_auth.py
@@ -1,6 +1,5 @@
 import asyncio
 import binascii
-import json
 import random
 import secrets
 import time
@@ -27,12 +26,27 @@ class TestAuthRoutes:
     async def test_create_token_wallet_ok(
         self, app: FastAPI, db: Database, client: AsyncClient, private_key: bytes, wallet: str
     ):
-        message_data = {"address": wallet, "signed_at": arrow.utcnow().isoformat()}
-        str_message = json.dumps(message_data, separators=(",", ":"))
-        message = encode_defunct(text=str_message)
-        signed_message = Web3().eth.account.sign_message(message, private_key=private_key)  # type: SignedMessage
+        nonce = 1234
+        signed_at = arrow.utcnow().isoformat()
+        message = f"""NewShades wants you to sign in with your web3 account
 
-        data = {"message": message_data, "signature": signed_message.signature.hex()}
+        {wallet}
+
+        URI: localhost
+        Nonce: {nonce}
+        Issued At: {signed_at}`;
+        """
+        encoded_message = encode_defunct(text=message)
+        signed_message = Web3().eth.account.sign_message(
+            encoded_message, private_key=private_key
+        )  # type: SignedMessage
+        data = {
+            "message": message,
+            "signature": signed_message.signature.hex(),
+            "signed_at": signed_at,
+            "nonce": nonce,
+            "address": wallet,
+        }
 
         response = await client.post("/auth/login", json=data)
         assert response.status_code == 201
@@ -52,12 +66,27 @@ class TestAuthRoutes:
     async def test_login_with_same_wallet(
         self, app: FastAPI, db: Database, client: AsyncClient, private_key: bytes, wallet: str
     ):
-        message_data = {"address": wallet, "signed_at": arrow.utcnow().isoformat()}
-        str_message = json.dumps(message_data, separators=(",", ":"))
-        message = encode_defunct(text=str_message)
-        signed_message = Web3().eth.account.sign_message(message, private_key=private_key)  # type: SignedMessage
+        nonce = 1234
+        signed_at = arrow.utcnow().isoformat()
+        message = f"""NewShades wants you to sign in with your web3 account
 
-        data = {"message": message_data, "signature": signed_message.signature.hex()}
+        {wallet}
+
+        URI: localhost
+        Nonce: {nonce}
+        Issued At: {signed_at}`;
+        """
+        encoded_message = encode_defunct(text=message)
+        signed_message = Web3().eth.account.sign_message(
+            encoded_message, private_key=private_key
+        )  # type: SignedMessage
+        data = {
+            "message": message,
+            "signature": signed_message.signature.hex(),
+            "signed_at": signed_at,
+            "nonce": nonce,
+            "address": wallet,
+        }
 
         response = await client.post("/auth/login", json=data)
         assert response.status_code == 201
@@ -92,13 +121,27 @@ class TestAuthRoutes:
     async def test_login_wallet_with_lowercase_address(
         self, app: FastAPI, db: Database, client: AsyncClient, private_key: bytes, wallet: str
     ):
-        message_data = {"address": wallet.lower(), "signed_at": arrow.utcnow().isoformat()}
+        nonce = 1234
+        signed_at = arrow.utcnow().isoformat()
+        message = f"""NewShades wants you to sign in with your web3 account
 
-        str_message = json.dumps(message_data, separators=(",", ":"))
-        message = encode_defunct(text=str_message)
-        signed_message = Web3().eth.account.sign_message(message, private_key=private_key)  # type: SignedMessage
+        {wallet}
 
-        data = {"message": message_data, "signature": signed_message.signature.hex()}
+        URI: localhost
+        Nonce: {nonce}
+        Issued At: {signed_at}`;
+        """
+        encoded_message = encode_defunct(text=message)
+        signed_message = Web3().eth.account.sign_message(
+            encoded_message, private_key=private_key
+        )  # type: SignedMessage
+        data = {
+            "message": message,
+            "signature": signed_message.signature.hex(),
+            "signed_at": signed_at,
+            "nonce": nonce,
+            "address": wallet.lower(),
+        }
 
         response = await client.post("/auth/login", json=data)
         assert response.status_code == 201
@@ -118,11 +161,28 @@ class TestAuthRoutes:
         private_key = "0x" + priv
         acct = Account.from_key(private_key)
         wallet = acct.address
-        message_data = {"address": wallet, "signed_at": arrow.utcnow().isoformat()}
-        str_message = json.dumps(message_data, separators=(",", ":"))
-        message = encode_defunct(text=str_message)
-        signed_message = Web3().eth.account.sign_message(message, private_key=private_key)  # type: SignedMessage
-        data = {"message": message_data, "signature": signed_message.signature.hex()}
+
+        nonce = 1234
+        signed_at = arrow.utcnow().isoformat()
+        message = f"""NewShades wants you to sign in with your web3 account
+        
+{wallet}
+
+URI: localhost
+Nonce: {nonce}
+Issued At: {signed_at}`;
+"""
+        encoded_message = encode_defunct(text=message)
+        signed_message = Web3().eth.account.sign_message(
+            encoded_message, private_key=private_key
+        )  # type: SignedMessage
+        data = {
+            "message": message,
+            "signature": signed_message.signature.hex(),
+            "signed_at": signed_at,
+            "nonce": nonce,
+            "address": wallet,
+        }
 
         members = await get_items({"server": server.id}, result_obj=ServerMember, current_user=current_user, size=None)
         assert len(members) == 1

--- a/app/tests/services/test_auth_service.py
+++ b/app/tests/services/test_auth_service.py
@@ -1,5 +1,3 @@
-import json
-
 import arrow
 import pytest
 from eth_account.messages import encode_defunct
@@ -13,12 +11,27 @@ from app.services.users import get_user_by_id
 class TestAuthService:
     @pytest.mark.asyncio
     async def test_generate_wallet_token_ok(self, db, private_key: bytes, wallet: str):
-        message_data = {"address": wallet, "signed_at": arrow.utcnow().isoformat()}
-        str_message = json.dumps(message_data, separators=(",", ":"))
-        message = encode_defunct(text=str_message)
-        signed_message = Web3().eth.account.sign_message(message, private_key=private_key)
+        nonce = 1234
+        signed_at = arrow.utcnow().isoformat()
+        message = f"""NewShades wants you to sign in with your web3 account
 
-        data = {"message": message_data, "signature": signed_message.signature}
+            {wallet}
+
+            URI: localhost
+            Nonce: {nonce}
+            Issued At: {signed_at}`;
+            """
+
+        encoded_message = encode_defunct(text=message)
+        signed_message = Web3().eth.account.sign_message(encoded_message, private_key=private_key)
+
+        data = {
+            "message": message,
+            "signature": signed_message.signature.hex(),
+            "signed_at": signed_at,
+            "nonce": nonce,
+            "address": wallet,
+        }
 
         token = await generate_wallet_token(data)
         decrypted_token = decode_jwt_token(token)


### PR DESCRIPTION
Stop forcing clients to send a proper JSON as the message, but instead send additional info outside of it. Allows for signature messages to be more verbose and user-friendly.

Also increased signature expiry time to 30s