### PR TITLE
make dates timezone aware and happy

### DIFF
--- a/app/models/base.py
+++ b/app/models/base.py
@@ -8,10 +8,10 @@ from app.helpers.db_utils import instance
 
 @instance.register
 class DatetimeMixin(MixinDocument):
-    created_at = fields.DateTimeField(default=datetime.datetime.utcnow)
+    created_at = fields.AwareDateTimeField(default=lambda: datetime.datetime.now(datetime.timezone.utc))
 
     # TODO: add default updated_at + trigger on each update
-    updated_at = fields.DateTimeField()
+    updated_at = fields.AwareDateTimeField()
 
 
 @instance.register

--- a/app/models/server.py
+++ b/app/models/server.py
@@ -23,7 +23,7 @@ class ServerMember(APIDocument):
     user = fields.ReferenceField(User, required=True)
 
     display_name = fields.StrField()
-    joined_at = fields.DateTimeField(default=datetime.datetime.utcnow)
+    joined_at = fields.AwareDateTimeField(default=lambda: datetime.datetime.now(datetime.timezone.utc))
 
     class Meta:
         collection_name = "server_members"


### PR DESCRIPTION
I wrongly assumed that using `utcnow()` for the default dates would handle any timezone conversions by default. That doesn't seem to be the case.

umongo needs to know specifically that a date field is `aware` rather than `naive`, so we're using the `AwareDateTimeField ` instead.

Apart from that, TIL that `datetime.utcnow()` doesn't actually set the `tzinfo` on the date, thus creating a naive datetime localized in UTC, which is very different than a aware datetime in UTC. I've used `arrow` in the past for dates, so haven't really dealt w/ this before, fun!

In any case, using `datetime.datetime.now(datetime.timezone.utc)` creates an aware datetime on UTC timezone.