### PR TITLE
add zlib compression to pusher messages

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     pusher_key: Optional[str]
     pusher_secret: Optional[str]
     pusher_cluster: Optional[str]
+    pusher_compression: Optional[str]
 
     sentry_dsn: Optional[str]
 

--- a/app/helpers/compression.py
+++ b/app/helpers/compression.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import zlib
 from base64 import b64encode
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,9 @@ def _zlib_compress(data: str):
     return compressed_data
 
 
-async def compress_data(data: dict, compression_type="zlib"):
+async def compress_data(data: dict, compression_type: Optional[str] = "zlib"):
+    if not compression_type:
+        compression_type = "zlib"
     json_data = json.dumps(data)
     original_size = sys.getsizeof(json_data)
     if compression_type == "zlib":

--- a/app/helpers/compression.py
+++ b/app/helpers/compression.py
@@ -1,0 +1,29 @@
+import json
+import logging
+import sys
+import zlib
+from base64 import b64encode
+
+logger = logging.getLogger(__name__)
+
+
+def _zlib_compress(data: str):
+    bytes_data = data.encode("utf-8")
+    b64 = b64encode(zlib.compress(bytes_data))
+    compressed_data = b64.decode("ascii")
+    return compressed_data
+
+
+async def compress_data(data: dict, compression_type="zlib"):
+    json_data = json.dumps(data)
+    original_size = sys.getsizeof(json_data)
+    if compression_type == "zlib":
+        compressed_data = _zlib_compress(json_data)
+    else:
+        raise NotImplementedError(f"unknown compression type: {compression_type}")
+
+    compressed_size = sys.getsizeof(compressed_data)
+    logger.debug(
+        "compressed original data from %s to %s bytes using %s", original_size, compressed_size, compression_type
+    )
+    return compressed_data

--- a/app/services/websockets.py
+++ b/app/services/websockets.py
@@ -1,6 +1,8 @@
 import logging
 from typing import List, Optional, Union
 
+from app.config import get_settings
+from app.helpers.compression import compress_data
 from app.helpers.websockets import pusher_client
 from app.helpers.ws_events import WebSocketServerEvent
 from app.models.base import APIDocument
@@ -38,6 +40,12 @@ async def pusher_broadcast_messages(
     message: Optional[Message] = None,
     pusher_channel: Optional[str] = None,
 ):
+    settings = get_settings()
+    if settings.pusher_compression:
+        compressed_data = await compress_data(data, compression_type=settings.pusher_compression)
+        compressed_object = {"compressed": {"data": compressed_data, "alg": settings.pusher_compression}}
+        data = compressed_object
+
     pusher_channels = current_user.online_channels
     if message:
         pusher_channels = await get_online_channels(message=message, current_user=current_user)

--- a/app/services/websockets.py
+++ b/app/services/websockets.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import sys
 from typing import List, Optional, Union
 
 from app.config import get_settings
@@ -41,7 +43,8 @@ async def pusher_broadcast_messages(
     pusher_channel: Optional[str] = None,
 ):
     settings = get_settings()
-    if settings.pusher_compression:
+    json_data_bytes = sys.getsizeof(json.dumps(data))
+    if settings.pusher_compression or json_data_bytes > 10_000:
         compressed_data = await compress_data(data, compression_type=settings.pusher_compression)
         compressed_object = {"compressed": {"data": compressed_data, "alg": settings.pusher_compression}}
         data = compressed_object


### PR DESCRIPTION
Fixes #35

Add the ability to compress data being sent to Pusher. Created an environment variable `PUSHER_COMPRESSION` that defines which algorithm to use for compression. To start with, only `zlib` is allowed, but we can add support for other algs (e.g. `brotli`) later on.