### PR TITLE
adding first version of image uploads

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -26,3 +26,7 @@ PUSHER_CLUSTER=
 
 # Sentry settings
 SENTRY_DSN=
+
+# Cloudflare settings
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_IMAGES_API_TOKEN=

--- a/app/config.py
+++ b/app/config.py
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
 
     sentry_dsn: Optional[str]
 
+    cloudflare_account_id: Optional[str]
+    cloudflare_images_api_token: Optional[str]
+
     class Config:
         env_file = ".env"
 

--- a/app/helpers/cloudflare.py
+++ b/app/helpers/cloudflare.py
@@ -1,0 +1,38 @@
+import logging
+from typing import List, Optional
+
+import aiohttp
+from aiohttp import FormData
+from fastapi import UploadFile
+
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+CLOUDFLARE_IMAGES_URL = "https://api.cloudflare.com/client/v4/accounts/%s/images/v1"
+
+
+async def upload_images(files: List[UploadFile], prefix: Optional[str] = ""):
+    settings = get_settings()
+    account_id = settings.cloudflare_account_id
+    url = CLOUDFLARE_IMAGES_URL % account_id
+
+    headers = {"Authorization": f"Bearer {settings.cloudflare_images_api_token}"}
+
+    images = []
+    async with aiohttp.ClientSession(headers=headers) as session:
+        for file in files:
+            content = await file.read()
+            data = FormData()
+            filename = file.filename
+            if prefix:
+                filename = f"{prefix}.{filename}"
+            data.add_field("file", value=content, filename=filename, content_type=file.content_type)
+            async with session.post(url, data=data) as resp:
+                if not resp.ok:
+                    logger.warning(f"problem storing file {file.filename}: {resp.status} {resp.text}")
+                json_resp = await resp.json()
+                result = json_resp["result"]
+                image_data = {"id": result["id"], "filename": result["filename"], "variants": result["variants"]}
+                images.append(image_data)
+    return images

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ from app.config import get_settings
 from app.helpers.db_utils import close_mongo_connection, connect_to_mongo, override_connect_to_mongo
 from app.helpers.logconf import log_configuration
 from app.middlewares import add_canonical_log_line, profile_request
-from app.routers import auth, base, channels, messages, servers, users, webhooks, websockets
+from app.routers import auth, base, channels, media, messages, servers, users, webhooks, websockets
 
 logging.config.dictConfig(log_configuration)
 logger = logging.getLogger(__name__)
@@ -61,6 +61,7 @@ def get_application(testing=False):
     app_.include_router(messages.router, prefix="/messages", tags=["messages"])
     app_.include_router(websockets.router, prefix="/websockets", tags=["websockets"])
     app_.include_router(webhooks.router, prefix="/webhooks", tags=["webhooks"])
+    app_.include_router(media.router, prefix="/media", tags=["media"])
 
     return app_
 

--- a/app/routers/media.py
+++ b/app/routers/media.py
@@ -1,0 +1,18 @@
+import http
+from typing import List
+
+from fastapi import APIRouter, Depends, File, UploadFile
+
+from app.dependencies import get_current_user
+from app.helpers.cloudflare import upload_images
+from app.models.user import User
+
+router = APIRouter()
+
+
+@router.post("/images", summary="Upload new image", status_code=http.HTTPStatus.CREATED)
+async def create_upload_image_files(
+    files: List[UploadFile] = File(...), current_user: User = Depends(get_current_user)
+):
+    images = await upload_images(files, prefix=str(current_user.id))
+    return images


### PR DESCRIPTION
Fixes #36 

Added new endpoint for uploading images: `POST /media/images`.

Trying out Cloudflare Images for this as it allows us to quickly create (and fetch) diff variants of the same image, i.e. with different cropping and aspect ratios. Also they have a great CDN.

Example `<form>` for uploading images:
```html
<form action="https://<api_endpoint>/media/images" enctype="multipart/form-data" method="post">
<input name="files" type="file" multiple>
<input type="submit">
</form>
```

The result is a list of objects like this:
```
[
   {
      "id":"4373563a-07c9-43bc-3a1a-7a1f6d96c600",
      "filename":"123.Screenshot%202021-11-19%20at%2014.38.39.png",
      "variants":[
         "https://imagedelivery.net/nLr2hkFWmbqKjH_rKSoB7g/4373563a-07c9-43bc-3a1a-7a1f6d96c600/public"
      ]
   }
]
```

