### PR TITLE
add exception handler for AssertionError

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,0 +1,11 @@
+import logging
+
+from starlette import status
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+async def assertion_exception_handler(request: Request, exc: AssertionError):
+    return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={"detail": "Problem with validating request"})

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 
 from app.config import get_settings
+from app.exceptions import assertion_exception_handler
 from app.helpers.db_utils import close_mongo_connection, connect_to_mongo, override_connect_to_mongo
 from app.helpers.logconf import log_configuration
 from app.middlewares import add_canonical_log_line, profile_request
@@ -52,6 +53,8 @@ def get_application(testing=False):
 
     if settings.profiling:
         app_.add_middleware(BaseHTTPMiddleware, dispatch=profile_request)
+
+    app_.add_exception_handler(AssertionError, assertion_exception_handler)
 
     app_.include_router(base.router)
     app_.include_router(auth.router, prefix="/auth", tags=["auth"])

--- a/app/tests/routers/test_auth.py
+++ b/app/tests/routers/test_auth.py
@@ -200,3 +200,31 @@ class TestAuthRoutes:
         await asyncio.sleep(random.random(), loop=event_loop)
         members = await get_items({"server": server.id}, result_obj=ServerMember, current_user=current_user, size=None)
         assert len(members) == 2
+
+    @pytest.mark.asyncio
+    async def test_login_wallet_with_assertion_error(
+        self, app: FastAPI, db: Database, client: AsyncClient, private_key: bytes, wallet: str
+    ):
+        nonce = 1234
+        signed_at = arrow.utcnow().isoformat()
+        message = f"""NewShades wants you to sign in with your web3 account
+
+            {wallet}
+
+            URI: localhost
+            Nonce: {nonce}
+            Issued At: {signed_at}"""
+        encoded_message = encode_defunct(text=message)
+        signed_message = Web3().eth.account.sign_message(
+            encoded_message, private_key=private_key
+        )  # type: SignedMessage
+        data = {
+            "message": message + "corrupt",
+            "signature": signed_message.signature.hex(),
+            "signed_at": signed_at,
+            "nonce": nonce,
+            "address": wallet.lower(),
+        }
+
+        response = await client.post("/auth/login", json=data)
+        assert response.status_code == 400


### PR DESCRIPTION
Fixes #43 

Using `assert x == y` raises an `AssertionError` which wasn't being handled by the API and ended up in a `500 Internal Server Error` and unnecessary sentry issue. 