### PR TITLE
Adding message formatting support via blocks

### DIFF
--- a/app/helpers/message_utils.py
+++ b/app/helpers/message_utils.py
@@ -31,12 +31,12 @@ async def blockify_content(content: str) -> List[dict]:
 
 async def stringify_text_node(text_node):
     text = text_node.get("text", "")
-    if text_node.get("strikethrough"):
-        text = f"~{text}~"
-    if text_node.get("italic"):
-        text = f"_{text}_"
     if text_node.get("bold"):
         text = f"*{text}*"
+    if text_node.get("italic"):
+        text = f"_{text}_"
+    if text_node.get("strikethrough"):
+        text = f"~{text}~"
 
     return text
 

--- a/app/helpers/message_utils.py
+++ b/app/helpers/message_utils.py
@@ -70,5 +70,4 @@ async def stringify_blocks(blocks: List[dict]) -> str:
         elements.append(await stringify_element(block))
 
     text = "\n".join(elements)
-    logger.debug(f"text: {text}")
     return text

--- a/app/helpers/message_utils.py
+++ b/app/helpers/message_utils.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -20,3 +21,46 @@ async def get_message_content_mentions(content):
         mentions.append((mention_type, mention_id))
 
     return mentions
+
+
+async def blockify_content(content: str) -> List[dict]:
+    paragraphs = content.split("\n")
+    blocks = [{"type": "paragraph", "children": [{"text": paragraph}]} for paragraph in paragraphs]
+    return blocks
+
+
+async def stringify_paragraph(paragraph_block):
+    paragraph_text = ""
+    for element in paragraph_block.get("children"):
+        text = element.get("text")
+        if element.get("bold"):
+            paragraph_text += f"**{text}**"
+        elif element.get("italic"):
+            paragraph_text += f"*{text}*"
+        elif element.get("strikethrough"):
+            paragraph_text += f"~~{text}~~"
+        elif element.get("type") == "user":
+            ref = element.get("ref")
+            paragraph_text += f"<@u:{ref}>"
+        else:
+            paragraph_text += text
+    return paragraph_text
+
+
+async def stringify_blocks(blocks: List[dict]) -> str:
+    text_lines = []
+    for block in blocks:
+        logger.debug(f"block: {block}")
+        parsed_text = ""
+        block_type = block.get("type")
+        if block_type in ["paragraph", "link"]:
+            parsed_text = await stringify_paragraph(block)
+        else:
+            logger.warning(f"unknown block type: {block_type}")
+
+        logger.debug(f"parsed text: {parsed_text}")
+        text_lines.append(parsed_text)
+
+    text = "\n".join(text_lines)
+    logger.debug(f"text: {text}")
+    return text

--- a/app/helpers/message_utils.py
+++ b/app/helpers/message_utils.py
@@ -31,14 +31,14 @@ async def blockify_content(content: str) -> List[dict]:
 
 async def stringify_text_node(text_node):
     text = text_node.get("text", "")
+    if text_node.get("strikethrough"):
+        text = f"~{text}~"
+    if text_node.get("italic"):
+        text = f"_{text}_"
     if text_node.get("bold"):
-        return f"**{text}**"
-    elif text_node.get("italic"):
-        return f"_{text}_"
-    elif text_node.get("strikethrough"):
-        return f"~~{text}~~"
-    else:
-        return text
+        text = f"*{text}*"
+
+    return text
 
 
 async def stringify_node(node: dict) -> str:

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -23,7 +23,8 @@ class Message(APIDocument):
     server = fields.ReferenceField("Server", required=False, default=None)
     author = fields.ReferenceField("User", required=True)
 
-    content = fields.StrField()  # TODO: prolly not only a string
+    content = fields.StrField()
+    blocks = fields.ListField(fields.DictField)
 
     edited_at = fields.AwareDateTimeField(required=False, default=None)
 

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -23,8 +23,8 @@ class Message(APIDocument):
     server = fields.ReferenceField("Server", required=False, default=None)
     author = fields.ReferenceField("User", required=True)
 
-    content = fields.StrField()
-    blocks = fields.ListField(fields.DictField)
+    content = fields.StrField(required=False, default="")
+    blocks = fields.ListField(fields.DictField, default=[])
 
     edited_at = fields.AwareDateTimeField(required=False, default=None)
 

--- a/app/schemas/messages.py
+++ b/app/schemas/messages.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import Field
+from pydantic import Field, root_validator, validator
 
 from app.schemas.base import APIBaseCreateSchema, APIBaseSchema, APIBaseUpdateSchema, APIEmbeddedBaseSchema, PyObjectId
 
@@ -35,7 +35,27 @@ class MessageCreateSchema(APIBaseCreateSchema):
     content: Optional[str] = ""
     blocks: Optional[List[dict]] = []
 
+    @root_validator(pre=True)
+    def check_blocks_or_content_present(cls, values):
+        content = values.get("content", "")
+        blocks = values.get("blocks", [])
+        if not any([content, blocks]):
+            raise ValueError("either 'blocks' or 'content' is required")
+        return values
+
 
 class MessageUpdateSchema(APIBaseUpdateSchema):
     content: Optional[str] = ""
     blocks: Optional[List[dict]] = []
+
+    @validator("content", pre=True)
+    def check_content_not_empty(cls, v):
+        if v == "":
+            raise ValueError("content can't be empty string")
+        return v
+
+    @validator("blocks", pre=True)
+    def check_blocks_not_empty(cls, v):
+        if len(v) == 0:
+            raise ValueError("blocks can't be empty list")
+        return v

--- a/app/schemas/messages.py
+++ b/app/schemas/messages.py
@@ -33,9 +33,9 @@ class MessageCreateSchema(APIBaseCreateSchema):
     server: Optional[str]
     channel: str
     content: Optional[str]
-    blocks: List[dict]
+    blocks: Optional[List[dict]] = []
 
 
 class MessageUpdateSchema(APIBaseUpdateSchema):
     content: Optional[str]
-    blocks: Optional[List[dict]]
+    blocks: Optional[List[dict]] = []

--- a/app/schemas/messages.py
+++ b/app/schemas/messages.py
@@ -21,7 +21,8 @@ class MessageSchema(APIBaseSchema):
     author: PyObjectId = Field()
     server: Optional[PyObjectId] = Field()
     channel: PyObjectId = Field()
-    content: str
+    content: Optional[str]
+    blocks: Optional[List[dict]]
     reactions: List[MessageReactionSchema]
     mentions: List[MessageMentionSchema]
     edited_at: Optional[datetime]
@@ -31,8 +32,10 @@ class MessageSchema(APIBaseSchema):
 class MessageCreateSchema(APIBaseCreateSchema):
     server: Optional[str]
     channel: str
-    content: str
+    content: Optional[str]
+    blocks: List[dict]
 
 
 class MessageUpdateSchema(APIBaseUpdateSchema):
     content: Optional[str]
+    blocks: Optional[List[dict]]

--- a/app/schemas/messages.py
+++ b/app/schemas/messages.py
@@ -32,10 +32,10 @@ class MessageSchema(APIBaseSchema):
 class MessageCreateSchema(APIBaseCreateSchema):
     server: Optional[str]
     channel: str
-    content: Optional[str]
+    content: Optional[str] = ""
     blocks: Optional[List[dict]] = []
 
 
 class MessageUpdateSchema(APIBaseUpdateSchema):
-    content: Optional[str]
+    content: Optional[str] = ""
     blocks: Optional[List[dict]] = []

--- a/app/services/messages.py
+++ b/app/services/messages.py
@@ -63,8 +63,6 @@ async def update_message(message_id: str, update_data: MessageUpdateSchema, curr
     if not message.author == current_user:
         raise HTTPException(status_code=http.HTTPStatus.FORBIDDEN)
 
-    data = update_data.dict()
-
     if update_data.blocks and not update_data.content:
         update_data.content = await stringify_blocks(update_data.blocks)
     elif update_data.content and not update_data.blocks:
@@ -72,6 +70,7 @@ async def update_message(message_id: str, update_data: MessageUpdateSchema, curr
     else:
         pass
 
+    data = update_data.dict()
     changed_content = any([update_data.content, update_data.blocks])
     if changed_content:
         data.update({"edited_at": datetime.now(timezone.utc)})

--- a/app/tests/helpers/test_message_utils.py
+++ b/app/tests/helpers/test_message_utils.py
@@ -56,7 +56,7 @@ class TestMessageUtils:
                         "children": [{"text": "hey "}, {"text": "bold", "bold": True}, {"text": " text"}],
                     },
                 ],
-                "hey **bold** text",
+                "hey *bold* text",
             ),
             (
                 [
@@ -66,6 +66,32 @@ class TestMessageUtils:
                     },
                 ],
                 "hey _italic_ text",
+            ),
+            (
+                [
+                    {
+                        "type": "paragraph",
+                        "children": [
+                            {"text": "hey "},
+                            {"text": "strikethrough", "strikethrough": True},
+                            {"text": " text"},
+                        ],
+                    },
+                ],
+                "hey ~strikethrough~ text",
+            ),
+            (
+                [
+                    {
+                        "type": "paragraph",
+                        "children": [
+                            {"text": "hey "},
+                            {"strikethrough": True, "bold": True, "text": "all", "italic": True},
+                            {"text": " text"},
+                        ],
+                    },
+                ],
+                "hey *_~all~_* text",
             ),
             (
                 [
@@ -85,7 +111,7 @@ class TestMessageUtils:
                         ],
                     },
                 ],
-                "Hi **there**!\nHere's a link: [**google**](http://google.com/)",
+                "Hi *there*!\nHere's a link: [*google*](http://google.com/)",
             ),
             (
                 [

--- a/app/tests/helpers/test_message_utils.py
+++ b/app/tests/helpers/test_message_utils.py
@@ -91,7 +91,7 @@ class TestMessageUtils:
                         ],
                     },
                 ],
-                "hey *_~all~_* text",
+                "hey ~_*all*_~ text",
             ),
             (
                 [

--- a/app/tests/helpers/test_message_utils.py
+++ b/app/tests/helpers/test_message_utils.py
@@ -1,6 +1,8 @@
+from typing import List
+
 import pytest
 
-from app.helpers.message_utils import get_message_content_mentions
+from app.helpers.message_utils import get_message_content_mentions, stringify_blocks
 
 
 class TestMessageUtils:
@@ -28,3 +30,77 @@ class TestMessageUtils:
     )
     async def test_get_mentions(self, content, mentions):
         assert await get_message_content_mentions(content) == mentions
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "blocks, text",
+        [
+            ([], ""),
+            (
+                [{"type": "paragraph", "children": [{"text": "hey"}]}],
+                "hey",
+            ),
+            (
+                [
+                    {"type": "paragraph", "children": [{"text": "hey"}]},
+                    {"type": "paragraph", "children": [{"text": "there"}]},
+                    {"type": "paragraph", "children": []},
+                    {"type": "paragraph", "children": [{"text": "multiline text"}]},
+                ],
+                "hey\nthere\n\nmultiline text",
+            ),
+            (
+                [
+                    {
+                        "type": "paragraph",
+                        "children": [{"text": "hey "}, {"text": "bold", "bold": True}, {"text": " text"}],
+                    },
+                ],
+                "hey **bold** text",
+            ),
+            (
+                [
+                    {
+                        "type": "paragraph",
+                        "children": [{"text": "hey "}, {"text": "italic", "italic": True}, {"text": " text"}],
+                    },
+                ],
+                "hey _italic_ text",
+            ),
+            (
+                [
+                    {
+                        "type": "paragraph",
+                        "children": [{"text": "Hi "}, {"text": "there", "bold": True}, {"text": "!"}],
+                    },
+                    {
+                        "type": "paragraph",
+                        "children": [
+                            {"text": "Here's a link: "},
+                            {
+                                "type": "link",
+                                "url": "http://google.com/",
+                                "children": [{"text": "google", "bold": True}],
+                            },
+                        ],
+                    },
+                ],
+                "Hi **there**!\nHere's a link: [**google**](http://google.com/)",
+            ),
+            (
+                [
+                    {
+                        "type": "paragraph",
+                        "children": [
+                            {"text": "hey "},
+                            {"type": "user", "ref": "123123123"},
+                            {"text": ", you around?"},
+                        ],
+                    },
+                ],
+                "hey <@u:123123123>, you around?",
+            ),
+        ],
+    )
+    async def test_stringify_blocks(self, blocks: List[dict], text: str):
+        assert await stringify_blocks(blocks) == text

--- a/app/tests/routers/test_messages.py
+++ b/app/tests/routers/test_messages.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from pymongo.database import Database
 
+from app.helpers.message_utils import blockify_content
 from app.models.channel import Channel
 from app.models.message import Message, MessageReaction
 from app.models.server import Server
@@ -465,3 +466,84 @@ class TestMessagesRoutes:
         assert len(mentions) == 1
         assert mentions[0]["type"] == "user"
         assert mentions[0]["id"] == str(guest_user.id)
+
+    @pytest.mark.asyncio
+    async def test_create_message_with_blocks(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+    ):
+        text = "gm!"
+        blocks = await blockify_content(content=text)
+        data = {"blocks": blocks, "server": str(server.id), "channel": str(server_channel.id)}
+        response = await authorized_client.post("/messages", json=data)
+        assert response.status_code == 201
+        json_response = response.json()
+        assert json_response != {}
+        assert "content" in json_response
+        assert "blocks" in json_response
+        assert json_response["content"] == text
+        assert json_response["blocks"] == blocks
+        assert json_response["server"] == data["server"] == str(server.id)
+        assert json_response["channel"] == data["channel"] == str(server_channel.id)
+
+    @pytest.mark.asyncio
+    async def test_create_message_with_blocks_and_content(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+    ):
+        text = "gm!"
+        blocks = await blockify_content(content=text)
+        # take client's content as final 'content' value
+        content = "random stuff"
+        data = {"blocks": blocks, "content": content, "server": str(server.id), "channel": str(server_channel.id)}
+        response = await authorized_client.post("/messages", json=data)
+        assert response.status_code == 201
+        json_response = response.json()
+        assert json_response != {}
+        assert "content" in json_response
+        assert "blocks" in json_response
+        assert json_response["content"] == content
+        assert json_response["blocks"] == blocks
+        assert json_response["server"] == data["server"] == str(server.id)
+        assert json_response["channel"] == data["channel"] == str(server_channel.id)
+
+    @pytest.mark.asyncio
+    async def test_edit_message_blocks(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+        channel_message: Message,
+    ):
+        message = await get_item_by_id(
+            id_=channel_message.id, result_obj=Message, current_user=current_user
+        )  # type: Message
+        assert message.edited_at is None
+
+        content = "new message update!"
+        blocks = await blockify_content(content)
+        data = {"blocks": blocks}
+        response = await authorized_client.patch(f"/messages/{str(channel_message.id)}", json=data)
+        assert response.status_code == 200
+        json_response = response.json()
+
+        message = await get_item_by_id(id_=channel_message.id, result_obj=Message, current_user=current_user)
+        assert message is not None
+        assert json_response["id"] == str(message.id)
+        assert json_response["content"] == message.content == content
+        assert json_response["blocks"] == message.blocks == blocks
+        assert message.edited_at is not None
+        assert message.edited_at != message.created_at


### PR DESCRIPTION
The frontend is using a blocks-based approach to add formatting to messages (bold, italic, mentions, links, etc.). This PR adds support for messages to be created/edited using `blocks` rather than the previous pure-text `content`.