### PR TITLE
Add support for @here and friends mentions

### DIFF
--- a/app/helpers/message_utils.py
+++ b/app/helpers/message_utils.py
@@ -1,14 +1,19 @@
 import logging
 import re
-from typing import List
+from typing import List, Tuple
+
+from app.models.message import Message
 
 logger = logging.getLogger(__name__)
 
 MENTION_REFS_PATTERN = re.compile(r"(?!\b|\s)@<(?P<type>\w):(?P<id>[0-9a-f]{24})>", flags=re.IGNORECASE)
-MENTION_TYPE_MAPPING = {"u": "user"}
+BROADCAST_MENTION_REFS_PATTERN = re.compile(r"(?!\b|\s)@<(?P<type>b):(?P<range>.+?)>", flags=re.IGNORECASE)
+
+MENTION_TYPE_MAPPING = {"u": "user", "b": "broadcast"}
+MENTION_BROADCAST_RANGES = ["here", "channel", "everyone"]
 
 
-async def get_message_content_mentions(content):
+async def get_message_content_mentions(content: str) -> List[Tuple[str, str]]:
     mentions = []
     for match in re.finditer(MENTION_REFS_PATTERN, content):
         mention_type_matched = match.group("type")
@@ -20,7 +25,31 @@ async def get_message_content_mentions(content):
         mention_id = match.group("id")
         mentions.append((mention_type, mention_id))
 
+    for match in re.finditer(BROADCAST_MENTION_REFS_PATTERN, content):
+        mention_type_matched = match.group("type")
+        mention_type = MENTION_TYPE_MAPPING.get(mention_type_matched)
+        if not mention_type:
+            logger.warning(f"unexpected matched mention type '{mention_type_matched}' in {match.group()}")
+            continue
+
+        mention_range = match.group("range")
+        if mention_range not in MENTION_BROADCAST_RANGES:
+            logger.warning(f"ignoring unknown broadcast range: {mention_range}")
+            continue
+
+        mentions.append((mention_type, mention_range))
+
     return mentions
+
+
+async def get_message_mentions(message: Message) -> List[Tuple[str, str]]:
+    if not message.content and message.blocks:
+        message.content = await stringify_blocks(message.blocks)
+
+    if not message.content:
+        raise Exception("can't fetch mentions from message without content. [message=%s]", str(message.id))
+
+    return await get_message_content_mentions(message.content)
 
 
 async def blockify_content(content: str) -> List[dict]:
@@ -58,7 +87,9 @@ async def stringify_element(element: dict) -> str:
     elif el_type == "link":
         return f"[{children}]({element.get('url')})"
     elif el_type == "user":
-        return f"<@u:{element.get('ref')}>"
+        return f"@<u:{element.get('ref')}>"
+    elif el_type == "broadcast":
+        return f"@<b:{element.get('ref')}>"
     else:
         logger.warning(f"unknown element type: {el_type}")
         return ""

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -1,4 +1,4 @@
-from umongo import EmbeddedDocument, fields, validate
+from umongo import EmbeddedDocument, fields
 
 from app.helpers.db_utils import instance
 from app.models.base import APIDocument
@@ -9,12 +9,6 @@ class MessageReaction(EmbeddedDocument):
     emoji = fields.StrField(required=True)
     count = fields.IntField(default=1)
     users = fields.ListField(fields.ReferenceField("User"))
-
-
-@instance.register
-class MessageMention(EmbeddedDocument):
-    type = fields.StrField(validate=validate.OneOf(["user"]), required=True)
-    id = fields.ObjectIdField(required=True)
 
 
 @instance.register
@@ -30,7 +24,6 @@ class Message(APIDocument):
 
     reactions = fields.ListField(fields.EmbeddedField(MessageReaction), default=[])
     embeds = fields.ListField(fields.DictField, default=[])
-    mentions = fields.ListField(fields.EmbeddedField(MessageMention), default=[])
 
     reply_to = fields.ReferenceField("Message", required=False, default=None)
 

--- a/app/schemas/messages.py
+++ b/app/schemas/messages.py
@@ -12,11 +12,6 @@ class MessageReactionSchema(APIEmbeddedBaseSchema):
     count: int
 
 
-class MessageMentionSchema(APIEmbeddedBaseSchema):
-    type: str
-    id: PyObjectId
-
-
 class MessageSchema(APIBaseSchema):
     author: PyObjectId = Field()
     server: Optional[PyObjectId] = Field()
@@ -24,7 +19,6 @@ class MessageSchema(APIBaseSchema):
     content: Optional[str]
     blocks: Optional[List[dict]]
     reactions: List[MessageReactionSchema]
-    mentions: List[MessageMentionSchema]
     edited_at: Optional[datetime]
     embeds: List[dict]
     reply_to: Optional[PyObjectId]

--- a/app/services/messages.py
+++ b/app/services/messages.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 from fastapi import HTTPException
 
-from app.helpers.message_utils import blockify_content, get_message_content_mentions, stringify_blocks
+from app.helpers.message_utils import blockify_content, get_message_mentions, stringify_blocks
 from app.helpers.queue_utils import queue_bg_task, queue_bg_tasks
 from app.helpers.ws_events import WebSocketServerEvent
 from app.models.base import APIDocument
@@ -29,13 +29,6 @@ async def create_message(message_model: MessageCreateSchema, current_user: User)
         pass
 
     message = await create_item(item=message_model, result_obj=Message, current_user=current_user, user_field="author")
-    mentions = await get_message_content_mentions(message.content)
-    if mentions:
-        mentions_obj = [{"type": mention_type, "id": mention_id} for mention_type, mention_id in mentions]
-        data = {"mentions": mentions_obj}
-        message = await update_item(item=message, data=data)
-
-        # TODO: broadcast notifications...
 
     bg_tasks = [
         (broadcast_message_event, (str(message.id), str(current_user.id), WebSocketServerEvent.MESSAGE_CREATE)),
@@ -49,6 +42,7 @@ async def create_message(message_model: MessageCreateSchema, current_user: User)
             ),
         ),
         (post_process_message_creation, (str(message.id), str(current_user.id))),
+        (process_message_mentions, (str(message.id), str(current_user.id))),
     ]
 
     # mypy has some issues with changing Callable signatures so we have to exclude that type check:
@@ -220,6 +214,20 @@ async def post_process_message_creation(message_id: str, user_id: str):
         return
 
     await update_item(item=message, data=data, current_user=user)
+
+
+async def process_message_mentions(message_id: str, user_id: str):
+    user = await get_user_by_id(user_id=user_id)
+    message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=user)
+    mentions = await get_message_mentions(message)
+    if not mentions:
+        return
+
+    mentions_obj = [{"type": mention_type, "id": mention_id} for mention_type, mention_id in mentions]
+    data = {"mentions": mentions_obj}
+    await update_item(item=message, data=data)
+
+    # TODO: broadcast notifications...
 
 
 async def create_reply_message(

--- a/app/tests/helpers/test_message_utils.py
+++ b/app/tests/helpers/test_message_utils.py
@@ -137,7 +137,29 @@ class TestMessageUtils:
                         ],
                     },
                 ],
-                "hey <@u:123123123>, you around?",
+                "hey @<u:123123123>, you around?",
+            ),
+            (
+                [
+                    {
+                        "type": "paragraph",
+                        "children": [
+                            {"text": "hey "},
+                            {"type": "broadcast", "ref": "here"},
+                            {"text": "!"},
+                        ],
+                    },
+                ],
+                "hey @<b:here>!",
+            ),
+            (
+                [
+                    {
+                        "type": "unknown",
+                        "children": [{"text": "hey"}],
+                    },
+                ],
+                "",
             ),
         ],
     )

--- a/app/tests/helpers/test_message_utils.py
+++ b/app/tests/helpers/test_message_utils.py
@@ -26,9 +26,22 @@ class TestMessageUtils:
                     ("user", "61ee8893e89d5fe35c198ef2"),
                 ],
             ),
+            ("hey\n\ntest @<u:61ee8893e89d5fe35c198ef2>", [("user", "61ee8893e89d5fe35c198ef2")]),
         ],
     )
-    async def test_get_mentions(self, content, mentions):
+    async def test_get_user_mentions(self, content, mentions):
+        assert await get_message_content_mentions(content) == mentions
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content, mentions",
+        [
+            ("hey @<b:here>", [("broadcast", "here")]),
+            ("hey @<b:channel>", [("broadcast", "channel")]),
+            ("hey @<b:everyone>", [("broadcast", "everyone")]),
+        ],
+    )
+    async def test_get_broadcast_mentions(self, content, mentions):
         assert await get_message_content_mentions(content) == mentions
 
     @pytest.mark.asyncio

--- a/app/tests/routers/test_messages.py
+++ b/app/tests/routers/test_messages.py
@@ -470,7 +470,7 @@ class TestMessagesRoutes:
     ):
 
         data = {
-            "content": f"hey @<b:here>, what up?",
+            "content": "hey @<b:here>, what up?",
             "server": str(server.id),
             "channel": str(server_channel.id),
         }

--- a/app/tests/routers/test_messages.py
+++ b/app/tests/routers/test_messages.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from pymongo.database import Database
 
-from app.helpers.message_utils import blockify_content
+from app.helpers.message_utils import blockify_content, get_message_mentions
 from app.models.channel import Channel
 from app.models.message import Message, MessageReaction
 from app.models.server import Server
@@ -381,7 +381,6 @@ class TestMessagesRoutes:
         authorized_client: AsyncClient,
         server: Server,
         server_channel: Channel,
-        channel_message: Message,
         create_new_user: Callable,
     ):
         guest_user = await create_new_user()
@@ -392,15 +391,13 @@ class TestMessagesRoutes:
         }
         response = await authorized_client.post("/messages", json=data)
         assert response.status_code == 201
-        json_response = response.json()
-        assert json_response != {}
-        assert "content" in json_response
-        assert json_response["content"] == data["content"]
-        assert "mentions" in json_response
-        mentions = json_response["mentions"]
+        message_id = response.json().get("id")
+        message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=current_user)
+        mentions = await get_message_mentions(message)
         assert len(mentions) == 1
-        assert mentions[0]["type"] == "user"
-        assert mentions[0]["id"] == str(guest_user.id)
+        mention_type, mention_ref = mentions[0]
+        assert mention_type == "user"
+        assert mention_ref == str(guest_user.id)
 
     @pytest.mark.asyncio
     async def test_create_message_with_user_multiple_mentions(
@@ -411,7 +408,6 @@ class TestMessagesRoutes:
         authorized_client: AsyncClient,
         server: Server,
         server_channel: Channel,
-        channel_message: Message,
         create_new_user: Callable,
     ):
         guest_user_1 = await create_new_user()
@@ -424,17 +420,16 @@ class TestMessagesRoutes:
         }
         response = await authorized_client.post("/messages", json=data)
         assert response.status_code == 201
-        json_response = response.json()
-        assert json_response != {}
-        assert "content" in json_response
-        assert json_response["content"] == data["content"]
-        assert "mentions" in json_response
-        mentions = json_response["mentions"]
+        message_id = response.json().get("id")
+        message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=current_user)
+        mentions = await get_message_mentions(message)
         assert len(mentions) == 2
-        assert mentions[0]["type"] == "user"
-        assert mentions[0]["id"] == str(guest_user_1.id)
-        assert mentions[1]["type"] == "user"
-        assert mentions[1]["id"] == str(guest_user_2.id)
+        mention_type, mention_ref = mentions[0]
+        assert mention_type == "user"
+        assert mention_ref == str(guest_user_1.id)
+        mention_type, mention_ref = mentions[1]
+        assert mention_type == "user"
+        assert mention_ref == str(guest_user_2.id)
 
     @pytest.mark.asyncio
     async def test_create_message_with_unknown_mention_types(
@@ -445,27 +440,185 @@ class TestMessagesRoutes:
         authorized_client: AsyncClient,
         server: Server,
         server_channel: Channel,
-        channel_message: Message,
         create_new_user: Callable,
     ):
         guest_user = await create_new_user()
-
         data = {
-            "content": f"hey @<u:{str(guest_user.id)}> and @<r:{str(ObjectId())}>, what up?",
+            "content": f"hey @<u:{str(guest_user.id)}> and @<x:{str(ObjectId())}>, what up?",
             "server": str(server.id),
             "channel": str(server_channel.id),
         }
         response = await authorized_client.post("/messages", json=data)
         assert response.status_code == 201
-        json_response = response.json()
-        assert json_response != {}
-        assert "content" in json_response
-        assert json_response["content"] == data["content"]
-        assert "mentions" in json_response
-        mentions = json_response["mentions"]
+        message_id = response.json().get("id")
+        message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=current_user)
+        mentions = await get_message_mentions(message)
         assert len(mentions) == 1
-        assert mentions[0]["type"] == "user"
-        assert mentions[0]["id"] == str(guest_user.id)
+        mention_type, mention_ref = mentions[0]
+        assert mention_type == "user"
+        assert mention_ref == str(guest_user.id)
+
+    @pytest.mark.asyncio
+    async def test_create_message_with_broadcast_mention(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+    ):
+
+        data = {
+            "content": f"hey @<b:here>, what up?",
+            "server": str(server.id),
+            "channel": str(server_channel.id),
+        }
+        response = await authorized_client.post("/messages", json=data)
+        assert response.status_code == 201
+        message_id = response.json().get("id")
+        message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=current_user)
+        mentions = await get_message_mentions(message)
+        assert len(mentions) == 1
+        mention_type, mention_ref = mentions[0]
+        assert mention_type == "broadcast"
+        assert mention_ref == "here"
+
+    @pytest.mark.asyncio
+    async def test_create_message_with_broadcast_and_user_mentions(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+        create_new_user: Callable,
+    ):
+        guest_user = await create_new_user()
+        data = {
+            "content": f"hey @<b:here> and @<u:{str(guest_user.id)}>, what up?",
+            "server": str(server.id),
+            "channel": str(server_channel.id),
+        }
+        response = await authorized_client.post("/messages", json=data)
+        assert response.status_code == 201
+        message_id = response.json().get("id")
+        message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=current_user)
+        mentions = await get_message_mentions(message)
+        assert len(mentions) == 2
+        mention_type, mention_ref = mentions[0]
+        assert mention_type == "user"
+        assert mention_ref == str(guest_user.id)
+        mention_type, mention_ref = mentions[1]
+        assert mention_type == "broadcast"
+        assert mention_ref == "here"
+
+    @pytest.mark.asyncio
+    async def test_create_message_blocks_with_user_mentions(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+        create_new_user: Callable,
+    ):
+        guest_user = await create_new_user()
+        blocks = [
+            {
+                "type": "paragraph",
+                "children": [
+                    {"text": "hey "},
+                    {"type": "user", "ref": str(guest_user.id)},
+                    {"text": ", you around?"},
+                ],
+            },
+        ]
+        data = {"blocks": blocks, "server": str(server.id), "channel": str(server_channel.id)}
+        response = await authorized_client.post("/messages", json=data)
+        assert response.status_code == 201
+        message_id = response.json().get("id")
+        message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=current_user)
+        mentions = await get_message_mentions(message)
+        assert len(mentions) == 1
+        mention_type, mention_ref = mentions[0]
+        assert mention_type == "user"
+        assert mention_ref == str(guest_user.id)
+
+    @pytest.mark.asyncio
+    async def test_create_message_blocks_with_user_and_broadcast_mentions(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+        create_new_user: Callable,
+    ):
+        guest_user = await create_new_user()
+        blocks = [
+            {
+                "type": "paragraph",
+                "children": [
+                    {"text": "hey "},
+                    {"type": "user", "ref": str(guest_user.id)},
+                    {"text": " and "},
+                    {"type": "broadcast", "ref": "channel"},
+                    {"text": ", you around?"},
+                ],
+            },
+        ]
+        data = {"blocks": blocks, "server": str(server.id), "channel": str(server_channel.id)}
+        response = await authorized_client.post("/messages", json=data)
+        assert response.status_code == 201
+        message_id = response.json().get("id")
+        message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=current_user)
+        mentions = await get_message_mentions(message)
+        assert len(mentions) == 2
+        mention_type, mention_ref = mentions[0]
+        assert mention_type == "user"
+        assert mention_ref == str(guest_user.id)
+        mention_type, mention_ref = mentions[1]
+        assert mention_type == "broadcast"
+        assert mention_ref == "channel"
+
+    @pytest.mark.asyncio
+    async def test_create_message_blocks_with_user_and_broadcast_unknown_mentions(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+        create_new_user: Callable,
+    ):
+        guest_user = await create_new_user()
+        blocks = [
+            {
+                "type": "paragraph",
+                "children": [
+                    {"text": "hey "},
+                    {"type": "user", "ref": str(guest_user.id)},
+                    {"text": " and "},
+                    {"type": "broadcast", "ref": "unknown"},
+                    {"text": ", you around?"},
+                ],
+            },
+        ]
+        data = {"blocks": blocks, "server": str(server.id), "channel": str(server_channel.id)}
+        response = await authorized_client.post("/messages", json=data)
+        assert response.status_code == 201
+        message_id = response.json().get("id")
+        message = await get_item_by_id(id_=message_id, result_obj=Message, current_user=current_user)
+        mentions = await get_message_mentions(message)
+        assert len(mentions) == 1
+        mention_type, mention_ref = mentions[0]
+        assert mention_type == "user"
+        assert mention_ref == str(guest_user.id)
 
     @pytest.mark.asyncio
     async def test_create_message_with_blocks(


### PR DESCRIPTION
Fixes #60

Using slack's 'broadcast' nomenclature and support the following groups: `@here`, `@channel` and `@everyone`

```
{
   "blocks": [
      {
         "type": "paragraph",
         "children": [
            { "text": "hey " },
            { "type": "broadcast", "ref": "here" },
            { "text": ", what up?" }
         ]
      }
   ]
}
```

Also removed the `mentions` list from the message object. Until there's a clear reason to store it, rather not have to maintain that functionality.