### PR TITLE
Roles and permissions

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,13 +1,21 @@
 import logging
+from typing import List
 
 import marshmallow
 from starlette import status
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from app.helpers.permissions import APIPermissionError
-
 logger = logging.getLogger(__name__)
+
+
+class APIPermissionError(Exception):
+    def __init__(self, needed_permissions: List[str], user_permissions: List[str]):
+        self.needed_permissions = needed_permissions
+        self.user_permissions = user_permissions
+        self.message = f"needed: {needed_permissions} | user: {user_permissions}"
+
+        super().__init__(self.message)
 
 
 async def assertion_exception_handler(request: Request, exc: AssertionError):

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -10,10 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 class APIPermissionError(Exception):
-    def __init__(self, needed_permissions: List[str], user_permissions: List[str]):
+    def __init__(self, message: str = None, needed_permissions: List[str] = None, user_permissions: List[str] = None):
         self.needed_permissions = needed_permissions
         self.user_permissions = user_permissions
-        self.message = f"needed: {needed_permissions} | user: {user_permissions}"
+        self.message = message or f"needed: {needed_permissions} | user: {user_permissions}"
 
         super().__init__(self.message)
 

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -5,6 +5,8 @@ from starlette import status
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from app.helpers.permissions import APIPermissionError
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,3 +25,8 @@ async def marshmallow_validation_error_handler(request: Request, exc: marshmallo
 async def type_error_handler(request: Request, exc: TypeError):
     logger.warning(f"marshmallow validation error: {exc}")
     return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={"detail": "Problem with request data"})
+
+
+async def api_permissions_error_handler(request: Request, exc: APIPermissionError):
+    logger.warning(f"api permission error: {exc}")
+    return JSONResponse(status_code=status.HTTP_403_FORBIDDEN, content={"detail": "Not enough permissions"})

--- a/app/helpers/channels.py
+++ b/app/helpers/channels.py
@@ -52,22 +52,22 @@ async def fetch_channel_data(channel_id: Optional[str]) -> Optional[Dict[str, An
         return None
 
     cached_channel = await cache.client.hgetall(f"channel:{channel_id}")
-    if not cached_channel:
-        channel = await get_item_by_id(id_=channel_id, result_obj=Channel)
-        if not channel:
-            return None
+    if cached_channel:
+        return cached_channel
 
-        dict_channel = {
-            "kind": channel.kind,
-        }
+    channel = await get_item_by_id(id_=channel_id, result_obj=Channel)
+    if not channel:
+        return None
 
-        if channel.kind == "dm":
-            dict_channel["members"] = ",".join([str(member.pk) for member in channel.members])
+    dict_channel = {
+        "kind": channel.kind,
+    }
 
-        if channel.kind == "server":
-            dict_channel["server"] = str(channel.server.pk)
+    if channel.kind == "dm":
+        dict_channel["members"] = ",".join([str(member.pk) for member in channel.members])
 
-        await cache.client.hset(f"channel:{channel_id}", mapping=dict_channel)
-        return dict_channel
+    if channel.kind == "server":
+        dict_channel["server"] = str(channel.server.pk)
 
-    return cached_channel
+    await cache.client.hset(f"channel:{channel_id}", mapping=dict_channel)
+    return dict_channel

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 from enum import Enum
-from typing import List
+from typing import List, Optional, Set
 
 from bson import ObjectId
 
@@ -58,113 +58,68 @@ async def has_permissions(needed_permissions: List[str], user_permissions: dict,
     return all([req_permission in overwritten_user_permissions for req_permission in needed_permissions])
 
 
-async def fetch_base_permissions(user: User, server: Server) -> List[str]:
-    permissions = []
-
-    if server.owner == user:
-        logger.debug("server owner has all permissions")
-        return ALL_PERMISSIONS
-
-    # TODO: add admin flag with specific permission overwrite
-
-    member = await get_item(filters={"server": server.pk, "user": user.pk}, result_obj=ServerMember, current_user=user)
-    if not member:
-        logger.warning("user (%s) doesn't belong to server (%s)", str(user.pk), str(server.pk))
-        return []
-
-    roles = [await role.fetch() for role in member.roles]
-    for role in roles:
-        logger.debug("extending permissions w/ role: %s (%s)", role.name, str(role.pk))
-        permissions.extend(role.permissions)
-
-    # remove duplicates
-    permissions = list(set(permissions))
-
-    return permissions
-
-
 async def fetch_permission_overwrites(channel_id: str = None, user: User = None):
     return []
 
 
-async def full_handle_permissions(func_args, func_kwargs, req_permissions):
-    permissions = [p.value for p in req_permissions]
-    logger.debug(f"required permissions: {permissions}")
+async def _fetch_channel_from_kwargs(kwargs: dict) -> Optional[str]:
+    channel_id = kwargs.get("channel_id")
 
-    # TODO: cache and reuse permission results
-
-    current_user = func_kwargs.get("current_user", None)  # type: User
-    if not current_user:
-        raise Exception(f"missing current_user from method. args: {func_args} | kwargs: {func_kwargs}")
-
-    channel_id = func_kwargs.get("channel_id")
-    server_id = None
-
-    channel_model = func_kwargs.get("channel_model")
-    if channel_model:
-        server_id = str(channel_model.server)
-
-    message_model = func_kwargs.get("message_model")
+    message_model = kwargs.get("message_model")
     if message_model and not channel_id:
         channel_id = str(message_model.channel)
 
-    if not channel_id and not server_id:
-        raise Exception(f"no channel and server found in kwargs: {func_kwargs}")
+    return channel_id
 
-    if server_id:
-        server = await get_item_by_id(id_=server_id, result_obj=Server, current_user=current_user)
-    elif channel_id:
-        channel = await get_item_by_id(id_=channel_id, result_obj=Channel, current_user=current_user)
-        if not channel.server:
-            logger.warning("ignoring complex permission checks for DMs")
-            return DEFAULT_DM_PERMISSIONS
-        server = await channel.server.fetch()
-    else:
-        raise Exception("missing channel_id or server_id from data")
 
-    # user_permissions = await fetch_base_permissions(user=current_user, server=server)
-    user_permissions = set()
+async def _fetch_server_from_kwargs(kwargs: dict) -> Optional[str]:
+    server_id = kwargs.get("server_id")
 
-    if server.owner == current_user:
-        logger.debug("server owner has all permissions")
-        return
+    channel_model = kwargs.get("channel_model")
+    if channel_model:
+        server_id = str(channel_model.server)
 
-    # TODO: add admin flag with specific permission overwrite
+    return server_id
+
+
+async def calc_permissions(current_user: User, channel_id: Optional[str], server: Server) -> Set[str]:
+    user_permissions: Set[str] = set()
 
     member = await get_item(
-        filters={"server": server.pk, "user": current_user.pk}, result_obj=ServerMember, current_user=current_user
+        filters={"server": server.pk, "user": current_user.pk},
+        result_obj=ServerMember,
+        current_user=current_user,
     )
     if not member:
         logger.warning("user (%s) doesn't belong to server (%s)", str(current_user.pk), str(server.pk))
-        raise APIPermissionError(needed_permissions=permissions, user_permissions=list(user_permissions))
-
-    if not channel_id and server:
-        # TODO: later, admins should be able to do some actions without channel (channels.create, etc.)
-        # TODO: refactor this code once everything is divided and conquered
-        logger.warning("without channel_id, using server-wide role permissions. ignoring any overwrites.")
-        server_wide_user_permissions = await fetch_base_permissions(user=current_user, server=server)
-        if not all([req_permission in server_wide_user_permissions for req_permission in permissions]):
-            raise APIPermissionError(needed_permissions=permissions, user_permissions=server_wide_user_permissions)
-        else:
-            return
-
-    channel = await get_item_by_id(id_=channel_id, result_obj=Channel, current_user=current_user)
-    section = await get_item(
-        filters={"server": server.pk, "channels": ObjectId(channel_id)}, result_obj=Section, current_user=current_user
-    )
-
-    section_overwrites = {}
-    if section:
-        section_overwrites = {
-            overwrite.role.pk: set(overwrite.permissions) for overwrite in section.permission_overwrites
-        }
-    channel_overwrites = {overwrite.role.pk: set(overwrite.permissions) for overwrite in channel.permission_overwrites}
-
-    logger.debug("section overwrites: %s", section_overwrites)
-    logger.debug("channel overwrites: %s", channel_overwrites)
+        return user_permissions
 
     roles = [await role.fetch() for role in member.roles]
     logger.debug("user has roles: %s", [(str(r.pk), r.name) for r in roles])
+
+    # fetch from cache
+    channel_overwrites = {}
+    section_overwrites = {}
+
+    if channel_id:
+        channel = await get_item_by_id(id_=channel_id, result_obj=Channel, current_user=current_user)
+        channel_overwrites = {
+            overwrite.role.pk: set(overwrite.permissions) for overwrite in channel.permission_overwrites
+        }
+
+        section = await get_item(
+            filters={"server": server.pk, "channels": ObjectId(channel_id)},
+            result_obj=Section,
+            current_user=current_user,
+        )
+
+        if section:
+            section_overwrites = {
+                overwrite.role.pk: set(overwrite.permissions) for overwrite in section.permission_overwrites
+            }
+
+    logger.debug("section overwrites: %s", section_overwrites)
+    logger.debug("channel overwrites: %s", channel_overwrites)
 
     for role in roles:
         logger.debug("fetching role permissions for: %s (%s)", role.name, str(role.pk))
@@ -182,19 +137,57 @@ async def full_handle_permissions(func_args, func_kwargs, req_permissions):
 
         user_permissions |= role_permissions
 
-    # remove duplicates
-    user_permissions = list(user_permissions)
-    logger.debug("user permissions: %s", user_permissions)
+    return user_permissions
 
-    if not all([req_permission in user_permissions for req_permission in permissions]):
-        raise APIPermissionError(needed_permissions=permissions, user_permissions=user_permissions)
+
+async def fetch_user_permissions(func_kwargs: dict, current_user: User) -> List[str]:
+    channel_id = await _fetch_channel_from_kwargs(func_kwargs)
+    server_id = await _fetch_server_from_kwargs(func_kwargs)
+
+    if not channel_id and not server_id:
+        logger.error("no channel and server found. kwargs: %s", func_kwargs)
+        raise Exception(f"no channel and server found in kwargs: {func_kwargs}")
+
+    # 3. fetch relevant data from DB (or cache?)
+    if server_id:
+        server = await get_item_by_id(id_=server_id, result_obj=Server, current_user=current_user)
+    elif channel_id:
+        channel = await get_item_by_id(id_=channel_id, result_obj=Channel, current_user=current_user)
+        if not channel.server:
+            return DEFAULT_DM_PERMISSIONS
+        server = await channel.server.fetch()
+    else:
+        raise Exception("missing channel_id or server_id from data")
+
+    if server.owner == current_user:
+        logger.debug("server owner has all permissions")
+        return ALL_PERMISSIONS
+
+    # TODO: add admin flag with specific permission overwrite
+
+    # 4. start calculating permissions
+    user_permissions = await calc_permissions(current_user=current_user, channel_id=channel_id, server=server)
+
+    return list(user_permissions)
 
 
 def needs(permissions):
     def decorator_needs(func):
         @functools.wraps(func)
         async def wrapper_needs(*args, **kwargs):
-            await full_handle_permissions(func_args=args, func_kwargs=kwargs, req_permissions=permissions)
+            str_permissions = [p.value for p in permissions]
+            logger.debug(f"required permissions: {str_permissions}")
+
+            current_user: User = kwargs.get("current_user", None)
+            if not current_user:
+                raise Exception(f"missing current_user from method. args: {args} | kwargs: {kwargs}")
+
+            user_permissions = await fetch_user_permissions(func_kwargs=kwargs, current_user=current_user)
+            logger.debug("user permissions: %s", user_permissions)
+
+            if not all([req_permission in user_permissions for req_permission in str_permissions]):
+                raise APIPermissionError(needed_permissions=str_permissions, user_permissions=user_permissions)
+
             value = await func(*args, **kwargs)
             return value
 

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -164,8 +164,8 @@ async def calc_permissions(user: User, channel_id: Optional[str], server_id: str
         channel_overwrites = await _fetch_channel_overwrites(channel_id=channel_id)
         section_overwrites = await _fetch_section_overwrites(channel_id=channel_id)
 
-    logger.debug("section overwrites: %s", section_overwrites)
-    logger.debug("channel overwrites: %s", channel_overwrites)
+    if channel_overwrites or section_overwrites:
+        logger.debug("overwrites. section: %s | channel: %s", section_overwrites, channel_overwrites)
 
     user_permissions = await _calc_final_permissions(
         user_roles=roles,
@@ -191,7 +191,6 @@ async def fetch_user_permissions(channel_id: Optional[str], server_id: Optional[
         raise Exception("need a server_id at this stage!")
 
     if await is_server_owner(user=user, server_id=server_id):
-        logger.debug("server owner has all permissions")
         return ALL_PERMISSIONS
 
     # TODO: add admin flag with specific permission overwrite
@@ -214,8 +213,6 @@ def needs(permissions):
                 capture_exception(e)
                 raise e
 
-            logger.debug(f"required permissions: {str_permissions}")
-
             current_user: User = kwargs.get("current_user", None)
             if not current_user:
                 logger.error("no current user found. args: %s | kwargs: %s", args, kwargs)
@@ -231,7 +228,6 @@ def needs(permissions):
             user_permissions = await fetch_user_permissions(
                 user=current_user, channel_id=channel_id, server_id=server_id
             )
-            logger.debug("user permissions: %s", user_permissions)
 
             if not all([req_permission in user_permissions for req_permission in str_permissions]):
                 raise APIPermissionError(needed_permissions=str_permissions, user_permissions=user_permissions)

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -251,7 +251,5 @@ async def is_server_owner(user: User, server_id: str):
         return cached_owner == str(user.pk)
 
     server = await get_item_by_id(id_=server_id, result_obj=Server)
-    is_owner = server.owner == user
-    if is_owner:
-        await cache.client.hset(f"server:{server_id}", "owner", str(user.pk))
-    return is_owner
+    await cache.client.hset(f"server:{server_id}", "owner", str(server.owner.pk))
+    return server.owner == user

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -5,6 +5,7 @@ from typing import List
 
 from bson import ObjectId
 
+from app.exceptions import APIPermissionError
 from app.models.channel import Channel
 from app.models.server import Server, ServerMember
 from app.models.user import User
@@ -22,6 +23,7 @@ class Permission(Enum):
     MEMBERS_KICK = "members.kick"
 
 
+# TODO: Move all of this to a constants file?
 ALL_PERMISSIONS = [p.value for p in Permission]
 
 DEFAULT_ROLE_PERMISSIONS = [
@@ -39,15 +41,6 @@ DEFAULT_DM_PERMISSIONS = [
         Permission.MESSAGES_CREATE,
     ]
 ]
-
-
-class APIPermissionError(Exception):
-    def __init__(self, needed_permissions: List[str], user_permissions: List[str]):
-        self.needed_permissions = needed_permissions
-        self.user_permissions = user_permissions
-        self.message = f"needed: {needed_permissions} | user: {user_permissions}"
-
-        super().__init__(self.message)
 
 
 async def has_permissions(nperms: List[str], uperms: dict, overwrites: dict = None):

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -7,6 +7,7 @@ from bson import ObjectId
 
 from app.exceptions import APIPermissionError
 from app.models.channel import Channel
+from app.models.section import Section
 from app.models.server import Server, ServerMember
 from app.models.user import User
 from app.services.crud import get_item, get_item_by_id
@@ -43,18 +44,18 @@ DEFAULT_DM_PERMISSIONS = [
 ]
 
 
-async def has_permissions(nperms: List[str], uperms: dict, overwrites: dict = None):
+async def has_permissions(needed_permissions: List[str], user_permissions: dict, overwrites: dict = None):
     if overwrites:
-        ow_roles = list(uperms.keys() & overwrites.keys())
+        ow_roles = list(user_permissions.keys() & overwrites.keys())
         for r in ow_roles:
-            uperms[r] = list(set(uperms[r]) & set(overwrites[r]))
+            user_permissions[r] = list(set(user_permissions[r]) & set(overwrites[r]))
 
-    all_uperms = []
-    for role, permissions in uperms.items():
-        all_uperms.extend(permissions)
-    all_uperms = list(set(all_uperms))
+    overwritten_user_permissions = []
+    for role, permissions in user_permissions.items():
+        overwritten_user_permissions.extend(permissions)
+    overwritten_user_permissions = list(set(overwritten_user_permissions))
 
-    return all([req_permission in all_uperms for req_permission in nperms])
+    return all([req_permission in overwritten_user_permissions for req_permission in needed_permissions])
 
 
 async def fetch_base_permissions(user: User, server: Server) -> List[str]:
@@ -82,60 +83,118 @@ async def fetch_base_permissions(user: User, server: Server) -> List[str]:
     return permissions
 
 
-async def fetch_user_permissions(user: User, channel_id: str = None, server_id: str = None) -> List[str]:
-    if channel_id:
-        channel = await get_item_by_id(id_=channel_id, result_obj=Channel, current_user=user)
+async def fetch_permission_overwrites(channel_id: str = None, user: User = None):
+    return []
+
+
+async def full_handle_permissions(func_args, func_kwargs, req_permissions):
+    permissions = [p.value for p in req_permissions]
+    logger.debug(f"required permissions: {permissions}")
+
+    # TODO: cache and reuse permission results
+
+    current_user = func_kwargs.get("current_user", None)  # type: User
+    if not current_user:
+        raise Exception(f"missing current_user from method. args: {func_args} | kwargs: {func_kwargs}")
+
+    channel_id = func_kwargs.get("channel_id")
+    server_id = None
+
+    channel_model = func_kwargs.get("channel_model")
+    if channel_model:
+        server_id = str(channel_model.server)
+
+    message_model = func_kwargs.get("message_model")
+    if message_model and not channel_id:
+        channel_id = str(message_model.channel)
+
+    if not channel_id and not server_id:
+        raise Exception(f"no channel and server found in kwargs: {func_kwargs}")
+
+    if server_id:
+        server = await get_item_by_id(id_=server_id, result_obj=Server, current_user=current_user)
+    elif channel_id:
+        channel = await get_item_by_id(id_=channel_id, result_obj=Channel, current_user=current_user)
         if not channel.server:
             logger.warning("ignoring complex permission checks for DMs")
             return DEFAULT_DM_PERMISSIONS
         server = await channel.server.fetch()
-    elif server_id:
-        server = await get_item_by_id(id_=server_id, result_obj=Server, current_user=user)
     else:
         raise Exception("missing channel_id or server_id from data")
 
-    user_permissions = await fetch_base_permissions(user, server=server)
+    # user_permissions = await fetch_base_permissions(user=current_user, server=server)
+    user_permissions = set()
 
-    # TODO: Check specific channel or section overrides
+    if server.owner == current_user:
+        logger.debug("server owner has all permissions")
+        return
 
-    return user_permissions
+    # TODO: add admin flag with specific permission overwrite
+
+    member = await get_item(
+        filters={"server": server.pk, "user": current_user.pk}, result_obj=ServerMember, current_user=current_user
+    )
+    if not member:
+        logger.warning("user (%s) doesn't belong to server (%s)", str(current_user.pk), str(server.pk))
+        raise APIPermissionError(needed_permissions=permissions, user_permissions=list(user_permissions))
+
+    if not channel_id and server:
+        # TODO: later, admins should be able to do some actions without channel (channels.create, etc.)
+        # TODO: refactor this code once everything is divided and conquered
+        logger.warning("without channel_id, using server-wide role permissions. ignoring any overwrites.")
+        server_wide_user_permissions = await fetch_base_permissions(user=current_user, server=server)
+        if not all([req_permission in server_wide_user_permissions for req_permission in permissions]):
+            raise APIPermissionError(needed_permissions=permissions, user_permissions=server_wide_user_permissions)
+        else:
+            return
+
+    channel = await get_item_by_id(id_=channel_id, result_obj=Channel, current_user=current_user)
+    section = await get_item(
+        filters={"server": server.pk, "channels": ObjectId(channel_id)}, result_obj=Section, current_user=current_user
+    )
+
+    section_overwrites = {}
+    if section:
+        section_overwrites = {
+            overwrite.role.pk: set(overwrite.permissions) for overwrite in section.permission_overwrites
+        }
+    channel_overwrites = {overwrite.role.pk: set(overwrite.permissions) for overwrite in channel.permission_overwrites}
+
+    logger.debug("section overwrites: %s", section_overwrites)
+    logger.debug("channel overwrites: %s", channel_overwrites)
+
+    roles = [await role.fetch() for role in member.roles]
+    logger.debug("user has roles: %s", [(str(r.pk), r.name) for r in roles])
+
+    for role in roles:
+        logger.debug("fetching role permissions for: %s (%s)", role.name, str(role.pk))
+        role_permissions = set(role.permissions)
+
+        c_permissions = channel_overwrites.get(role.pk)
+        if c_permissions is not None:
+            user_permissions |= c_permissions
+            continue
+
+        s_permissions = section_overwrites.get(role.pk)
+        if s_permissions is not None:
+            user_permissions |= s_permissions
+            continue
+
+        user_permissions |= role_permissions
+
+    # remove duplicates
+    user_permissions = list(user_permissions)
+    logger.debug("user permissions: %s", user_permissions)
+
+    if not all([req_permission in user_permissions for req_permission in permissions]):
+        raise APIPermissionError(needed_permissions=permissions, user_permissions=user_permissions)
 
 
 def needs(permissions):
     def decorator_needs(func):
         @functools.wraps(func)
         async def wrapper_needs(*args, **kwargs):
-            str_permissions = [p.value for p in permissions]
-
-            current_user = kwargs.get("current_user", None)  # type: User
-            if not current_user:
-                raise Exception(f"missing current_user from method. args: {args} | kwargs: {kwargs}")
-
-            # TODO: cache and reuse values
-
-            # Extract channel and server from args & kwargs
-            channel_id = kwargs.get("channel_id")
-            server_id = None
-
-            channel_model = kwargs.get("channel_model")
-            if channel_model:
-                server_id = str(channel_model.server)
-
-            message_model = kwargs.get("message_model")
-            if message_model:
-                channel_id = str(message_model.channel)
-
-            if not channel_id and not server_id:
-                raise Exception("no channel and server found")
-
-            user_permissions = await fetch_user_permissions(
-                user=current_user, channel_id=channel_id, server_id=server_id
-            )
-            logger.debug("user permissions: %s", user_permissions)
-
-            if not all([req_permission in user_permissions for req_permission in str_permissions]):
-                raise APIPermissionError(needed_permissions=str_permissions, user_permissions=user_permissions)
-
+            await full_handle_permissions(func_args=args, func_kwargs=kwargs, req_permissions=permissions)
             value = await func(*args, **kwargs)
             return value
 

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -24,6 +24,9 @@ class Permission(Enum):
 
     MEMBERS_KICK = "members.kick"
 
+    ROLES_LIST = "roles.list"
+    ROLES_CREATE = "roles.create"
+
 
 # TODO: Move all of this to a constants file?
 ALL_PERMISSIONS = [p.value for p in Permission]

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 from enum import Enum
 from typing import List
 
@@ -7,7 +8,9 @@ from bson import ObjectId
 from app.models.channel import Channel
 from app.models.server import Server, ServerMember
 from app.models.user import User
-from app.services.crud import get_item
+from app.services.crud import get_item, get_item_by_id
+
+logger = logging.getLogger(__name__)
 
 
 class Permission(Enum):
@@ -17,31 +20,59 @@ class Permission(Enum):
     MEMBERS_KICK = "members.kick"
 
 
-ALL_PERMISSIONS = [p for p in Permission]
+ALL_PERMISSIONS = [p.value for p in Permission]
+DEFAULT_ROLE_PERMISSIONS = [
+    p.value
+    for p in [
+        Permission.MESSAGES_LIST,
+        Permission.MESSAGES_CREATE,
+    ]
+]
 
 
 class APIPermissionError(Exception):
-    def __init__(self, needed_permissions: List[Permission], user_permissions: List[Permission]):
+    def __init__(self, needed_permissions: List[str], user_permissions: List[str]):
         self.needed_permissions = needed_permissions
         self.user_permissions = user_permissions
-        self.message = (
-            f"needed: [{', '.join([p.value for p in self.needed_permissions])}] | "
-            f"user: [{', '.join([p.value for p in self.user_permissions])}]"
-        )
+        self.message = f"needed: {needed_permissions} | user: {user_permissions}"
+
         super().__init__(self.message)
 
 
-async def fetch_base_permissions(user: User, server: Server = None) -> List[Permission]:
+async def fetch_base_permissions(user: User, server: Server) -> List[str]:
     permissions = []
 
-    if server and server.owner == user:
+    if server.owner == user:
+        logger.debug("server owner has all permissions")
         return ALL_PERMISSIONS
+
+    member = await get_item(filters={"server": server.pk, "user": user.pk}, result_obj=ServerMember, current_user=user)
+
+    if not member:
+        logger.warning("user (%s) doesn't belong to server (%s)", str(user.pk), str(server.pk))
+        return []
+
+    roles = [await role.fetch() for role in member.roles]
+    for role in roles:
+        logger.debug("extending permissions w/ role: %s (%s)", role.name, str(role.pk))
+        permissions.extend(role.permissions)
+
+    # remove duplicates
+    permissions = list(set(permissions))
 
     return permissions
 
 
-async def fetch_user_permissions(user: User, channel: Channel = None) -> List[Permission]:
-    user_permissions = await fetch_base_permissions(user)
+async def fetch_user_permissions(user: User, channel_id: str) -> List[str]:
+    channel = await get_item_by_id(id_=channel_id, result_obj=Channel, current_user=user)
+
+    if not channel.server:
+        logger.warning("ignoring complex permission checks for DMs")
+        return []
+
+    server = await channel.server.fetch()
+
+    user_permissions = await fetch_base_permissions(user, server=server)
 
     # TODO: Check specific channel or section overrides
 
@@ -54,13 +85,19 @@ def needs(permissions):
         async def wrapper_needs(*args, **kwargs):
             current_user = kwargs.get("current_user", None)  # type: User
             if not current_user:
-                raise Exception("missing current_user from method")
+                raise Exception(f"missing current_user from method. args: {args} | kwargs: {kwargs}")
 
-            # TODO: cache values
-            user_permissions = await fetch_user_permissions(user=current_user)
+            str_permissions = [p.value for p in permissions]
 
-            if not all([req_permission in user_permissions for req_permission in permissions]):
-                raise APIPermissionError(needed_permissions=permissions, user_permissions=user_permissions)
+            # TODO: cache and reuse values
+
+            channel_id = kwargs.get("channel_id")
+
+            user_permissions = await fetch_user_permissions(user=current_user, channel_id=channel_id)
+            print("user permissions", user_permissions)
+
+            if not all([req_permission in user_permissions for req_permission in str_permissions]):
+                raise APIPermissionError(needed_permissions=str_permissions, user_permissions=user_permissions)
 
             value = await func(*args, **kwargs)
             return value

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -1,10 +1,73 @@
+import functools
+from enum import Enum
+from typing import List
+
 from bson import ObjectId
 
-from app.models.server import ServerMember
+from app.models.channel import Channel
+from app.models.server import Server, ServerMember
 from app.models.user import User
 from app.services.crud import get_item
 
-# this file will become more dynamic with time
+
+class Permission(Enum):
+    MESSAGES_CREATE = "messages.create"
+    MESSAGES_LIST = "messages.list"
+
+    MEMBERS_KICK = "members.kick"
+
+
+ALL_PERMISSIONS = [p for p in Permission]
+
+
+class APIPermissionError(Exception):
+    def __init__(self, needed_permissions: List[Permission], user_permissions: List[Permission]):
+        self.needed_permissions = needed_permissions
+        self.user_permissions = user_permissions
+        self.message = (
+            f"needed: [{', '.join([p.value for p in self.needed_permissions])}] | "
+            f"user: [{', '.join([p.value for p in self.user_permissions])}]"
+        )
+        super().__init__(self.message)
+
+
+async def fetch_base_permissions(user: User, server: Server = None) -> List[Permission]:
+    permissions = []
+
+    if server and server.owner == user:
+        return ALL_PERMISSIONS
+
+    return permissions
+
+
+async def fetch_user_permissions(user: User, channel: Channel = None) -> List[Permission]:
+    user_permissions = await fetch_base_permissions(user)
+
+    # TODO: Check specific channel or section overrides
+
+    return user_permissions
+
+
+def needs(permissions):
+    def decorator_needs(func):
+        @functools.wraps(func)
+        async def wrapper_needs(*args, **kwargs):
+            current_user = kwargs.get("current_user", None)  # type: User
+            if not current_user:
+                raise Exception("missing current_user from method")
+
+            # TODO: cache values
+            user_permissions = await fetch_user_permissions(user=current_user)
+
+            if not all([req_permission in user_permissions for req_permission in permissions]):
+                raise APIPermissionError(needed_permissions=permissions, user_permissions=user_permissions)
+
+            value = await func(*args, **kwargs)
+            return value
+
+        return wrapper_needs
+
+    return decorator_needs
 
 
 async def user_belongs_to_server(user: User, server_id: str):

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -1,17 +1,19 @@
 import functools
+import json
 import logging
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 
 from bson import ObjectId
 from sentry_sdk import capture_exception
 
 from app.exceptions import APIPermissionError
+from app.helpers.cache_utils import cache
 from app.models.channel import Channel
 from app.models.section import Section
 from app.models.server import Server, ServerMember
-from app.models.user import User
-from app.services.crud import get_item, get_item_by_id
+from app.models.user import Role, User
+from app.services.crud import get_item, get_item_by_id, get_items
 
 logger = logging.getLogger(__name__)
 
@@ -68,80 +70,148 @@ async def _fetch_server_from_kwargs(kwargs: dict) -> Optional[str]:
     return server_id
 
 
-async def fetch_overwrites(channel: Optional[Channel]) -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
-    # TODO: fetch from cache
-    channel_overwrites: Dict[str, Any] = {}
-    section_overwrites: Dict[str, Any] = {}
-
-    if not channel:
-        return channel_overwrites, section_overwrites
-
-    channel_overwrites = {
-        str(overwrite.role.pk): set(overwrite.permissions) for overwrite in channel.permission_overwrites
-    }
-
-    section = await get_item(filters={"server": channel.server.pk, "channels": channel.pk}, result_obj=Section)
-    if section:
-        section_overwrites = {
-            str(overwrite.role.pk): set(overwrite.permissions) for overwrite in section.permission_overwrites
-        }
-
-    return channel_overwrites, section_overwrites
-
-
 async def _calc_final_permissions(
-    roles: Dict[str, Set[str]], section_overwrites: Dict[str, Set[str]], channel_overwrites: Dict[str, Set[str]]
+    user_roles: Dict[str, List[str]], section_overwrites: Dict[str, List[str]], channel_overwrites: Dict[str, List[str]]
 ) -> Set[str]:
     permissions = set()
-    for role_id, role_permissions in roles.items():
+    for role_id, role_permissions in user_roles.items():
         c_permissions = channel_overwrites.get(role_id)
         if c_permissions is not None:
-            permissions |= c_permissions
+            permissions |= set(c_permissions)
             continue
 
         s_permissions = section_overwrites.get(role_id)
         if s_permissions is not None:
-            permissions |= s_permissions
+            permissions |= set(s_permissions)
             continue
 
-        permissions |= role_permissions
+        permissions |= set(role_permissions)
 
     return permissions
 
 
-async def calc_permissions(member: ServerMember, channel: Optional[Channel]) -> Set[str]:
-    roles_list = [await role.fetch() for role in member.roles]
-    logger.debug("user has roles: %s", [(str(r.pk), r.name) for r in roles_list])
+async def get_user_roles(user: User, server_id: str) -> Dict[str, List[str]]:
+    cached_user_roles = await cache.client.hget(f"user:{str(user.pk)}", f"{server_id}.roles")
 
-    roles = {str(role.pk): set(role.permissions) for role in roles_list}
+    if not cached_user_roles:
+        member = await get_item(filters={"server": ObjectId(server_id), "user": user.pk}, result_obj=ServerMember)
+        if not member:
+            logger.warning("user (%s) doesn't belong to server (%s)", str(user.pk), server_id)
+            raise APIPermissionError(message="user does not belong to server")
 
-    channel_overwrites, section_overwrites = await fetch_overwrites(channel)
+        member_role_ids = [str(role.pk) for role in member.roles]
+        await cache.client.hset(f"user:{str(user.pk)}", f"{server_id}.roles", ",".join(member_role_ids))
+    else:
+        member_role_ids = cached_user_roles.split(",")
+
+    server_role_keys = [f"roles.{role_id}" for role_id in member_role_ids]
+    cached_server_roles = await cache.client.hmget(f"server:{server_id}", server_role_keys)
+
+    if any([cached is None for cached in cached_server_roles]):
+        db_roles = await get_items(
+            filters={"_id": {"$in": [ObjectId(role_id) for role_id in member_role_ids]}},
+            result_obj=Role,
+            current_user=user,
+        )
+
+        mapping = {f"roles.{str(role.pk)}": ",".join(role.permissions) for role in db_roles}
+        await cache.client.hset(f"server:{server_id}", mapping=mapping)
+        cached_server_roles = await cache.client.hmget(f"server:{server_id}", server_role_keys)
+
+    result = {pair[0]: pair[1].split(",") for pair in zip(member_role_ids, cached_server_roles)}
+    return result
+
+
+async def _fetch_section_overwrites(channel_id: str) -> Dict[str, List[str]]:
+    section_id = await cache.client.hget(f"channel:{channel_id}", "section")
+    cached_section_permissions = await cache.client.hget(f"section:{section_id}", "permissions")
+    if cached_section_permissions is not None:
+        return json.loads(cached_section_permissions)
+
+    section = await get_item(filters={"channels": ObjectId(channel_id)}, result_obj=Section)
+    if not section:
+        return {}
+
+    section_overwrites = {str(overwrite.role.pk): overwrite.permissions for overwrite in section.permission_overwrites}
+    await cache.client.hset(f"section:{str(section.pk)}", "permissions", json.dumps(section_overwrites))
+    # TODO: this should be done on creating sections, not here...
+    await cache.client.hset(f"channel:{channel_id}", "section", str(section.pk))
+
+    return section_overwrites
+
+
+async def _fetch_channel_overwrites(channel_id: str) -> Dict[str, List[str]]:
+    channel_cache_key = f"channel:{channel_id}"
+    cached_channel_permissions = await cache.client.hget(channel_cache_key, "permissions")
+
+    if cached_channel_permissions is not None:
+        return json.loads(cached_channel_permissions)
+
+    channel = await get_item_by_id(id_=channel_id, result_obj=Channel)
+    channel_overwrites = {str(overwrite.role.pk): overwrite.permissions for overwrite in channel.permission_overwrites}
+    await cache.client.hset(channel_cache_key, "permissions", json.dumps(channel_overwrites))
+    return channel_overwrites
+
+
+async def calc_permissions(user: User, channel_id: Optional[str], server_id: str) -> Set[str]:
+    roles = await get_user_roles(user=user, server_id=server_id)
+
+    channel_overwrites = {}
+    section_overwrites = {}
+
+    if channel_id:
+        channel_overwrites = await _fetch_channel_overwrites(channel_id=channel_id)
+        section_overwrites = await _fetch_section_overwrites(channel_id=channel_id)
+
     logger.debug("section overwrites: %s", section_overwrites)
     logger.debug("channel overwrites: %s", channel_overwrites)
 
     user_permissions = await _calc_final_permissions(
-        roles=roles,
-        channel_overwrites=channel_overwrites,
+        user_roles=roles,
         section_overwrites=section_overwrites,
+        channel_overwrites=channel_overwrites,
     )
     return user_permissions
 
 
-async def fetch_user_permissions(channel: Optional[Channel], server_id: Optional[str], user: User) -> List[str]:
-    if channel and channel.kind == "dm":
+async def _fetch_channel_info(channel_id: Optional[str]):
+    if not channel_id:
+        return None
+
+    cached_channel = await cache.client.hgetall(f"channel:{channel_id}")
+    if not cached_channel:
+        channel = await get_item_by_id(id_=channel_id, result_obj=Channel)
+        if not channel:
+            return None
+
+        channel_mapping = {
+            "kind": channel.kind,
+        }
+        if channel.kind == "dm":
+            channel_mapping["members"] = ",".join([str(member.pk) for member in channel.members])
+
+        if channel.kind == "server":
+            channel_mapping["server"] = str(channel.server.pk)
+
+        await cache.client.hset(f"channel:{channel_id}", mapping=channel_mapping)
+        return channel_mapping
+
+    return cached_channel
+
+
+async def fetch_user_permissions(channel_id: Optional[str], server_id: Optional[str], user: User) -> List[str]:
+    channel_info = await _fetch_channel_info(channel_id=channel_id)
+    if channel_info and channel_info.get("kind") == "dm":
+        members = channel_info.get("members", []).split(",")
+        if str(user.pk) not in members:
+            raise APIPermissionError("user is not a member of DM channel")
         return DEFAULT_DM_PERMISSIONS
 
-    if channel and not server_id:
-        server_id = str(channel.server.pk)
+    if channel_info and not server_id:
+        server_id = channel_info.get("server")
 
     if not server_id:
         raise Exception("need a server_id at this stage!")
-
-    member = await get_item(filters={"server": ObjectId(server_id), "user": user.pk}, result_obj=ServerMember)
-
-    if not member:
-        logger.warning("user (%s) doesn't belong to server (%s)", str(user.pk), server_id)
-        return []
 
     if await is_server_owner(user=user, server_id=server_id):
         logger.debug("server owner has all permissions")
@@ -149,7 +219,7 @@ async def fetch_user_permissions(channel: Optional[Channel], server_id: Optional
 
     # TODO: add admin flag with specific permission overwrite
 
-    user_permissions = await calc_permissions(member=member, channel=channel)
+    user_permissions = await calc_permissions(user=user, channel_id=channel_id, server_id=server_id)
     return list(user_permissions)
 
 
@@ -157,6 +227,9 @@ def needs(permissions):
     def decorator_needs(func):
         @functools.wraps(func)
         async def wrapper_needs(*args, **kwargs):
+            if kwargs.pop("ignore_permissions", False):
+                return await func(*args, **kwargs)
+
             try:
                 str_permissions = [p.value for p in permissions]
             except AttributeError as e:
@@ -178,11 +251,9 @@ def needs(permissions):
                 logger.error("no channel and server found. kwargs: %s", kwargs)
                 raise Exception(f"no channel and server found in kwargs: {kwargs}")
 
-            channel = None
-            if channel_id:
-                channel = await get_item_by_id(id_=channel_id, result_obj=Channel)
-
-            user_permissions = await fetch_user_permissions(user=current_user, channel=channel, server_id=server_id)
+            user_permissions = await fetch_user_permissions(
+                user=current_user, channel_id=channel_id, server_id=server_id
+            )
             logger.debug("user permissions: %s", user_permissions)
 
             if not all([req_permission in user_permissions for req_permission in str_permissions]):
@@ -202,5 +273,12 @@ async def user_belongs_to_server(user: User, server_id: str):
 
 
 async def is_server_owner(user: User, server_id: str):
+    cached_owner = await cache.client.hget(f"server:{server_id}", "owner")
+    if cached_owner:
+        return cached_owner == str(user.pk)
+
     server = await get_item_by_id(id_=server_id, result_obj=Server)
-    return server.owner == user
+    is_owner = server.owner == user
+    if is_owner:
+        await cache.client.hset(f"server:{server_id}", "owner", str(user.pk))
+    return is_owner

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -105,6 +105,9 @@ async def get_user_roles(user: User, server_id: str) -> Dict[str, List[str]]:
     else:
         member_role_ids = cached_user_roles.split(",")
 
+    if not member_role_ids:
+        return {}
+
     server_role_keys = [f"roles.{role_id}" for role_id in member_role_ids]
     cached_server_roles = await cache.client.hmget(f"server:{server_id}", server_role_keys)
 

--- a/app/helpers/sections.py
+++ b/app/helpers/sections.py
@@ -1,0 +1,29 @@
+import json
+from typing import Dict, List, Optional
+
+from bson import ObjectId
+
+from app.helpers.cache_utils import cache
+from app.models.section import Section
+from app.services.crud import get_item
+
+
+async def fetch_section_permission_ow(channel_id: Optional[str]) -> Dict[str, List[str]]:
+    if not channel_id:
+        return {}
+
+    section_id = await cache.client.hget(f"channel:{channel_id}", "section")
+    cached_section_permissions = await cache.client.hget(f"section:{section_id}", "permissions")
+    if cached_section_permissions is not None:
+        return json.loads(cached_section_permissions)
+
+    section = await get_item(filters={"channels": ObjectId(channel_id)}, result_obj=Section)
+    if not section:
+        return {}
+
+    section_overwrites = {str(overwrite.role.pk): overwrite.permissions for overwrite in section.permission_overwrites}
+    await cache.client.hset(f"section:{str(section.pk)}", "permissions", json.dumps(section_overwrites))
+    # TODO: this should be done on creating sections, not here...
+    await cache.client.hset(f"channel:{channel_id}", "section", str(section.pk))
+
+    return section_overwrites

--- a/app/helpers/sections.py
+++ b/app/helpers/sections.py
@@ -13,12 +13,16 @@ async def fetch_section_permission_ow(channel_id: Optional[str]) -> Dict[str, Li
         return {}
 
     section_id = await cache.client.hget(f"channel:{channel_id}", "section")
+    if section_id is not None and section_id == "":
+        return {}
+
     cached_section_permissions = await cache.client.hget(f"section:{section_id}", "permissions")
     if cached_section_permissions is not None:
         return json.loads(cached_section_permissions)
 
     section = await get_item(filters={"channels": ObjectId(channel_id)}, result_obj=Section)
     if not section:
+        await cache.client.hset(f"channel:{channel_id}", "section", "")
         return {}
 
     section_overwrites = {str(overwrite.role.pk): overwrite.permissions for overwrite in section.permission_overwrites}

--- a/app/helpers/servers.py
+++ b/app/helpers/servers.py
@@ -1,0 +1,38 @@
+from typing import List
+
+from bson import ObjectId
+
+from app.helpers.cache_utils import cache
+from app.models.server import Server
+from app.models.user import Role, User
+from app.services.crud import get_item_by_id, get_items
+
+
+async def get_server_roles_permissions(role_ids: List[str], server_id: str):
+    server_role_keys = [f"roles.{role_id}" for role_id in role_ids]
+    server_roles_permissions = await cache.client.hmget(f"server:{server_id}", server_role_keys)
+
+    if all([cached is not None for cached in server_roles_permissions]):
+        return server_roles_permissions
+
+    db_roles = await get_items(
+        filters={"_id": {"$in": [ObjectId(role_id) for role_id in role_ids]}},
+        result_obj=Role,
+        current_user=None,
+    )
+
+    mapping = {f"roles.{str(role.pk)}": ",".join(role.permissions) for role in db_roles}
+    await cache.client.hset(f"server:{server_id}", mapping=mapping)
+
+    server_roles_permissions = await cache.client.hmget(f"server:{server_id}", server_role_keys)
+    return server_roles_permissions
+
+
+async def is_server_owner(user: User, server_id: str):
+    cached_owner = await cache.client.hget(f"server:{server_id}", "owner")
+    if cached_owner:
+        return cached_owner == str(user.pk)
+
+    server = await get_item_by_id(id_=server_id, result_obj=Server)
+    await cache.client.hset(f"server:{server_id}", "owner", str(server.owner.pk))
+    return server.owner == user

--- a/app/helpers/users.py
+++ b/app/helpers/users.py
@@ -1,0 +1,38 @@
+import logging
+from typing import Dict, List
+
+from bson import ObjectId
+
+from app.exceptions import APIPermissionError
+from app.helpers.cache_utils import cache
+from app.helpers.servers import get_server_roles_permissions
+from app.models.server import ServerMember
+from app.models.user import User
+from app.services.crud import get_item
+
+logger = logging.getLogger(__name__)
+
+
+async def get_user_roles_ids(user: User, server_id: str) -> List[str]:
+    cached_user_roles = await cache.client.hget(f"user:{str(user.pk)}", f"{server_id}.roles")
+    if cached_user_roles:
+        return cached_user_roles.split(",")
+
+    member = await get_item(filters={"server": ObjectId(server_id), "user": user.pk}, result_obj=ServerMember)
+    if not member:
+        logger.warning("user (%s) doesn't belong to server (%s)", str(user.pk), server_id)
+        raise APIPermissionError(message="user does not belong to server")
+
+    member_role_ids = [str(role.pk) for role in member.roles]
+    await cache.client.hset(f"user:{str(user.pk)}", f"{server_id}.roles", ",".join(member_role_ids))
+    return member_role_ids
+
+
+async def get_user_roles_permissions(user: User, server_id: str) -> Dict[str, List[str]]:
+    user_roles = await get_user_roles_ids(user=user, server_id=server_id)
+    if not user_roles:
+        return {}
+
+    server_roles_permissions = await get_server_roles_permissions(role_ids=user_roles, server_id=server_id)
+    result = {pair[0]: pair[1].split(",") for pair in zip(user_roles, server_roles_permissions)}
+    return result

--- a/app/main.py
+++ b/app/main.py
@@ -11,10 +11,16 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 
 from app.config import get_settings
-from app.exceptions import assertion_exception_handler, marshmallow_validation_error_handler, type_error_handler
+from app.exceptions import (
+    api_permissions_error_handler,
+    assertion_exception_handler,
+    marshmallow_validation_error_handler,
+    type_error_handler,
+)
 from app.helpers.cache_utils import close_redis_connection, connect_to_redis, connect_to_redis_testing
 from app.helpers.db_utils import close_mongo_connection, connect_to_mongo, create_all_indexes, override_connect_to_mongo
 from app.helpers.logconf import log_configuration
+from app.helpers.permissions import APIPermissionError
 from app.helpers.queue_utils import stop_background_tasks
 from app.middlewares import add_canonical_log_line, profile_request
 from app.routers import (
@@ -78,6 +84,7 @@ def get_application(testing=False):
     app_.add_exception_handler(AssertionError, assertion_exception_handler)
     app_.add_exception_handler(TypeError, type_error_handler)
     app_.add_exception_handler(ValidationError, marshmallow_validation_error_handler)
+    app_.add_exception_handler(APIPermissionError, api_permissions_error_handler)
 
     app_.include_router(base.router)
     app_.include_router(auth.router, prefix="/auth", tags=["auth"])

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 
 from app.config import get_settings
 from app.exceptions import (
+    APIPermissionError,
     api_permissions_error_handler,
     assertion_exception_handler,
     marshmallow_validation_error_handler,
@@ -20,7 +21,6 @@ from app.exceptions import (
 from app.helpers.cache_utils import close_redis_connection, connect_to_redis, connect_to_redis_testing
 from app.helpers.db_utils import close_mongo_connection, connect_to_mongo, create_all_indexes, override_connect_to_mongo
 from app.helpers.logconf import log_configuration
-from app.helpers.permissions import APIPermissionError
 from app.helpers.queue_utils import stop_background_tasks
 from app.middlewares import add_canonical_log_line, profile_request
 from app.routers import (

--- a/app/middlewares.py
+++ b/app/middlewares.py
@@ -19,12 +19,15 @@ def get_request_id() -> str:
 async def profile_request(request: Request, call_next):
     profiler = Profiler(async_mode="enabled")
     profiler.start()
+    start = time.perf_counter()
 
     response = await call_next(request)
 
     profiler.stop()
+    end = time.perf_counter()
+    ms = (end - start) * 1_000
     output_html = profiler.output_html(timeline=True)
-    profile_file_name = f"{arrow.now().timestamp()}-{request.method}-{request.url.path[1:].replace('/', '-')}"
+    profile_file_name = f"{arrow.now().timestamp()}_{ms:.2f}_{request.method}_{request.url.path[1:].replace('/', '-')}"
     with open(f"{profile_file_name}.html", "w") as f:
         f.write(output_html)
 

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -1,10 +1,16 @@
 from marshmallow import ValidationError
 from pymongo import ASCENDING
-from umongo import fields, validate
+from umongo import EmbeddedDocument, fields, validate
 
 from app.helpers.db_utils import instance
 from app.models.base import APIDocument
 from app.models.server import Server
+
+
+@instance.register
+class PermissionOverwrite(EmbeddedDocument):
+    role = fields.ReferenceField("Role")
+    permissions = fields.ListField(fields.StrField)
 
 
 @instance.register
@@ -21,6 +27,8 @@ class Channel(APIDocument):
     server = fields.ReferenceField(Server)
 
     name = fields.StrField()
+
+    permission_overwrites = fields.ListField(fields.EmbeddedField(PermissionOverwrite), default=[])
 
     def pre_insert(self):
         if self.kind == "dm":

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -1,16 +1,11 @@
 from marshmallow import ValidationError
 from pymongo import ASCENDING
-from umongo import EmbeddedDocument, fields, validate
+from umongo import fields, validate
 
 from app.helpers.db_utils import instance
 from app.models.base import APIDocument
+from app.models.common import PermissionOverwrite
 from app.models.server import Server
-
-
-@instance.register
-class PermissionOverwrite(EmbeddedDocument):
-    role = fields.ReferenceField("Role")
-    permissions = fields.ListField(fields.StrField)
 
 
 @instance.register

--- a/app/models/common.py
+++ b/app/models/common.py
@@ -1,0 +1,9 @@
+from umongo import EmbeddedDocument, fields
+
+from app.helpers.db_utils import instance
+
+
+@instance.register
+class PermissionOverwrite(EmbeddedDocument):
+    role = fields.ReferenceField("Role")
+    permissions = fields.ListField(fields.StrField)

--- a/app/models/section.py
+++ b/app/models/section.py
@@ -2,6 +2,7 @@ from umongo import fields
 
 from app.helpers.db_utils import instance
 from app.models.base import APIDocument
+from app.models.common import PermissionOverwrite
 
 
 @instance.register
@@ -11,6 +12,8 @@ class Section(APIDocument):
     channels = fields.ListField(fields.ReferenceField("Channel"), default=[])
 
     position = fields.IntField()
+
+    permission_overwrites = fields.ListField(fields.EmbeddedField(PermissionOverwrite), default=[])
 
     class Meta:
         collection_name = "sections"

--- a/app/models/server.py
+++ b/app/models/server.py
@@ -33,6 +33,8 @@ class ServerMember(APIDocument):
 
     joined_at = fields.AwareDateTimeField(default=get_mongo_utc_date)
 
+    roles = fields.ListField(fields.ReferenceField("Role"), default=[])
+
     class Meta:
         collection_name = "server_members"
         indexes = ["server", "user"]

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -18,3 +18,15 @@ class User(APIDocument):
     class Meta:
         collection_name = "users"
         indexes = ["wallet_address"]
+
+
+@instance.register
+class Role(APIDocument):
+    server = fields.ReferenceField("Server")
+
+    name = fields.StrField()
+    permissions = fields.ListField(fields.StrField)
+
+    class Meta:
+        collection_name = "roles"
+        indexes = ["server"]

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -52,7 +52,7 @@ async def get_list_messages(
 
 @router.get("/{channel_id}/messages/{message_id}", response_description="Get message", response_model=MessageSchema)
 async def get_specific_message(channel_id, message_id, current_user: User = Depends(get_current_user)):
-    return await get_message(channel_id, message_id, current_user=current_user)
+    return await get_message(channel_id=channel_id, message_id=message_id, current_user=current_user)
 
 
 @router.delete("/{channel_id}", response_description="Delete channel", response_model=EitherChannel)

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -46,7 +46,7 @@ async def get_list_messages(
     common_params: dict = Depends(common_parameters),
     current_user: User = Depends(get_current_user),
 ):
-    messages = await get_messages(channel_id, current_user=current_user, **common_params)
+    messages = await get_messages(channel_id=channel_id, current_user=current_user, **common_params)
     return messages
 
 

--- a/app/routers/messages.py
+++ b/app/routers/messages.py
@@ -27,7 +27,7 @@ async def post_create_message(
     message: MessageCreateSchema = Body(...),
     current_user: User = Depends(get_current_user),
 ):
-    return await create_message(message, current_user=current_user)
+    return await create_message(message_model=message, current_user=current_user)
 
 
 @router.patch(

--- a/app/routers/servers.py
+++ b/app/routers/servers.py
@@ -9,7 +9,9 @@ from app.models.user import User
 from app.schemas.channels import ServerChannelSchema
 from app.schemas.sections import SectionCreateSchema, SectionSchema
 from app.schemas.servers import ServerCreateSchema, ServerMemberSchema, ServerSchema, ServerUpdateSchema
+from app.schemas.users import RoleCreateSchema, RoleSchema
 from app.services.channels import get_server_channels
+from app.services.roles import create_role, get_roles
 from app.services.sections import create_section, get_sections, update_server_sections
 from app.services.servers import (
     create_server,
@@ -107,3 +109,18 @@ async def put_update_sections(
     server_id, section_data: List[SectionCreateSchema], current_user: User = Depends(get_current_user)
 ):
     return await update_server_sections(server_id=server_id, sections=section_data, current_user=current_user)
+
+
+@router.get("/{server_id}/roles", summary="List roles", response_model=List[RoleSchema])
+async def get_list_roles(server_id, current_user: User = Depends(get_current_user)):
+    return await get_roles(server_id=server_id, current_user=current_user)
+
+
+@router.post(
+    "/{server_id}/roles",
+    summary="Create a role",
+    response_model=RoleSchema,
+    status_code=http.HTTPStatus.CREATED,
+)
+async def post_create_role(server_id, role_data: RoleCreateSchema, current_user: User = Depends(get_current_user)):
+    return await create_role(server_id=server_id, role_model=role_data, current_user=current_user)

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -61,5 +61,5 @@ class RoleSchema(APIBaseSchema):
 
 class RoleCreateSchema(APIBaseCreateSchema):
     name: str
-    server: str
+    server: Optional[str]
     permissions: List[str]

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -1,8 +1,8 @@
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from pydantic import BaseModel
 
-from app.schemas.base import APIBaseCreateSchema, APIBaseSchema
+from app.schemas.base import APIBaseCreateSchema, APIBaseSchema, PyObjectId
 from app.schemas.servers import ServerMemberSchema
 
 
@@ -51,3 +51,15 @@ class UserUpdateSchema(APIBaseCreateSchema):
 
 class EitherUserProfile(BaseModel):
     __root__: Union[ServerMemberSchema, UserSchema]
+
+
+class RoleSchema(APIBaseSchema):
+    server: PyObjectId
+    name: str
+    permissions: List[str]
+
+
+class RoleCreateSchema(APIBaseCreateSchema):
+    name: str
+    server: str
+    permissions: List[str]

--- a/app/services/messages.py
+++ b/app/services/messages.py
@@ -35,6 +35,7 @@ from app.services.websockets import broadcast_current_user_event, broadcast_mess
 logger = logging.getLogger(__name__)
 
 
+@needs(permissions=[Permission.MESSAGES_CREATE])
 async def create_message(message_model: MessageCreateSchema, current_user: User) -> Union[Message, APIDocument]:
     if message_model.blocks and not message_model.content:
         message_model.content = await stringify_blocks(message_model.blocks)

--- a/app/services/messages.py
+++ b/app/services/messages.py
@@ -118,9 +118,9 @@ async def get_messages(channel_id: str, current_user: User, **common_params) -> 
     if not channel:
         raise Exception(f"couldn't find channel information for channel with id: {channel_id}")
 
-    filters = {"channel": channel_id}
+    filters = {"channel": ObjectId(channel_id)}
     if channel.get("kind") == "server":
-        filters = {"server": ObjectId(channel.get("server"))}
+        filters["server"] = ObjectId(channel.get("server"))
 
     around_id = common_params.pop("around", None)
     if around_id:

--- a/app/services/messages.py
+++ b/app/services/messages.py
@@ -118,11 +118,8 @@ async def get_messages(channel_id: str, current_user: User, **common_params) -> 
 
     filters = {}
     if channel.kind == "server":
-        # TODO: make sure user can list channel's messages (in server + proper permissions)
         filters = {"channel": channel.id, "server": channel.server.pk}
     elif channel.kind == "dm":
-        if current_user not in channel.members:
-            raise HTTPException(status_code=http.HTTPStatus.FORBIDDEN)
         filters = {"channel": channel.id}
 
     around_id = common_params.pop("around", None)

--- a/app/services/messages.py
+++ b/app/services/messages.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 from bson import ObjectId
 from fastapi import HTTPException
 
-from app.helpers.channels import fetch_channel_data, get_channel_online_users, get_channel_users, is_user_in_channel
+from app.helpers.channels import get_channel_online_users, get_channel_users, is_user_in_channel
 from app.helpers.message_utils import blockify_content, get_message_mentions, stringify_blocks
 from app.helpers.permissions import Permission, needs
 from app.helpers.queue_utils import queue_bg_task, queue_bg_tasks
@@ -114,22 +114,14 @@ async def delete_message(message_id: str, current_user: User):
 
 @needs(permissions=[Permission.MESSAGES_LIST])
 async def get_messages(channel_id: str, current_user: User, **common_params) -> List[Message]:
-    channel = await fetch_channel_data(channel_id=channel_id)
-    if not channel:
-        raise Exception(f"couldn't find channel information for channel with id: {channel_id}")
-
     filters = {"channel": ObjectId(channel_id)}
-    if channel.get("kind") == "server":
-        filters["server"] = ObjectId(channel.get("server"))
-
     around_id = common_params.pop("around", None)
     if around_id:
         return await _get_around_messages(
             around_message_id=around_id, filters=filters, current_user=current_user, **common_params
         )
 
-    messages = await get_items(filters=filters, result_obj=Message, current_user=current_user, **common_params)
-    return messages
+    return await get_items(filters=filters, result_obj=Message, current_user=current_user, **common_params)
 
 
 async def _get_around_messages(

--- a/app/services/messages.py
+++ b/app/services/messages.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 
 from app.helpers.channels import get_channel_online_users, get_channel_users, is_user_in_channel
 from app.helpers.message_utils import blockify_content, get_message_mentions, stringify_blocks
+from app.helpers.permissions import Permission, needs
 from app.helpers.queue_utils import queue_bg_task, queue_bg_tasks
 from app.helpers.ws_events import WebSocketServerEvent
 from app.models.base import APIDocument
@@ -110,6 +111,7 @@ async def delete_message(message_id: str, current_user: User):
     await delete_item(item=message)
 
 
+@needs(permissions=[Permission.MESSAGES_LIST])
 async def get_messages(channel_id: str, current_user: User, **common_params) -> List[Message]:
     channel = await get_item_by_id(id_=channel_id, result_obj=Channel, current_user=current_user)
 

--- a/app/services/roles.py
+++ b/app/services/roles.py
@@ -1,0 +1,20 @@
+from bson import ObjectId
+
+from app.helpers.cache_utils import cache
+from app.helpers.permissions import Permission, needs
+from app.models.user import Role, User
+from app.schemas.users import RoleCreateSchema
+from app.services.crud import create_item, get_items
+
+
+@needs(permissions=[Permission.ROLES_LIST])
+async def get_roles(server_id: str, current_user: User):
+    return await get_items(filters={"server": ObjectId(server_id)}, result_obj=Role, current_user=current_user)
+
+
+@needs(permissions=[Permission.ROLES_CREATE])
+async def create_role(server_id: str, role_model: RoleCreateSchema, current_user: User):
+    role_model.server = server_id
+    role = await create_item(role_model, result_obj=Role, current_user=current_user, user_field=None)
+    await cache.client.hset(f"server:{server_id}", f"roles.{str(role.pk)}", ",".join(role.permissions))
+    return role

--- a/app/services/servers.py
+++ b/app/services/servers.py
@@ -38,7 +38,9 @@ async def create_server(server_model: ServerCreateSchema, current_user: User) ->
     await join_server(server_id=str(created_server.pk), current_user=current_user, ignore_joining_rules=True)
 
     # create default role
-    role_schema = RoleCreateSchema(name="default", server=str(created_server.pk), permissions=DEFAULT_ROLE_PERMISSIONS)
+    role_schema = RoleCreateSchema(
+        name="@everyone", server=str(created_server.pk), permissions=DEFAULT_ROLE_PERMISSIONS
+    )
     await create_item(item=role_schema, result_obj=Role, current_user=current_user, user_field=None)
 
     return created_server
@@ -84,7 +86,7 @@ async def join_server(server_id: str, current_user: User, ignore_joining_rules: 
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User cannot join this server")
 
     default_roles = await get_items(
-        filters={"server": server.pk, "name": "default"},
+        filters={"server": server.pk, "name": "@everyone"},
         result_obj=Role,
         current_user=current_user,
         sort_by_direction=1,

--- a/app/services/servers.py
+++ b/app/services/servers.py
@@ -30,12 +30,12 @@ from app.services.websockets import broadcast_server_event
 async def create_server(server_model: ServerCreateSchema, current_user: User) -> Union[Server, APIDocument]:
     created_server = await create_item(server_model, result_obj=Server, current_user=current_user, user_field="owner")
 
+    # add owner as server member
+    await join_server(server_id=str(created_server.pk), current_user=current_user, ignore_joining_rules=True)
+
     default_channel_model = ServerChannelCreateSchema(name="lounge", server=str(created_server.pk))
     default_channel = await create_server_channel(channel_model=default_channel_model, current_user=current_user)
     await update_item(item=created_server, data={"system_channel": default_channel}, current_user=current_user)
-
-    # add owner as server member
-    await join_server(server_id=str(created_server.pk), current_user=current_user, ignore_joining_rules=True)
 
     # create default role
     role_schema = RoleCreateSchema(

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -125,13 +125,13 @@ async def dm_channel(current_user: User, server: Server) -> Union[Channel, APIDo
 @pytest.fixture
 async def channel_message(current_user: User, server: Server, server_channel: Channel):
     message = MessageCreateSchema(server=str(server.id), channel=str(server_channel.id), content="hey")
-    return await create_message(message, current_user=current_user)
+    return await create_message(message_model=message, current_user=current_user)
 
 
 @pytest.fixture
 async def direct_message(current_user: User, server: Server, dm_channel: Channel):
     message = MessageCreateSchema(channel=str(dm_channel.id), content="hey")
-    return await create_message(message, current_user=current_user)
+    return await create_message(message_model=message, current_user=current_user)
 
 
 @pytest.fixture

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -113,13 +113,13 @@ async def server(current_user: User) -> Union[Server, APIDocument]:
 @pytest.fixture
 async def server_channel(current_user: User, server: Server) -> Union[Channel, APIDocument]:
     server_channel = ServerChannelCreateSchema(kind="server", server=str(server.id), name="testing-channel")
-    return await create_server_channel(server_channel, current_user=current_user)
+    return await create_server_channel(channel_model=server_channel, current_user=current_user)
 
 
 @pytest.fixture
 async def dm_channel(current_user: User, server: Server) -> Union[Channel, APIDocument]:
     dm_channel = DMChannelCreateSchema(kind="dm", members=[str(current_user.id)])
-    return await create_dm_channel(dm_channel, current_user=current_user)
+    return await create_dm_channel(channel_model=dm_channel, current_user=current_user)
 
 
 @pytest.fixture

--- a/app/tests/helpers/test_permissions_helper.py
+++ b/app/tests/helpers/test_permissions_helper.py
@@ -35,49 +35,49 @@ class TestPermissionsHelper:
     @pytest.mark.parametrize(
         "required, user_roles, section_overwrites, channel_overwrites, expected_result",
         [
-            (["messages.create"], {"@everyone": {"messages.create"}}, {}, {}, True),
-            (["messages.list"], {"@everyone": {"messages.list", "messages.create"}}, {}, {}, True),
-            (["messages.create"], {"@everyone": {"messages.list"}}, {}, {}, False),
+            (["messages.create"], {"@everyone": ["messages.create"]}, {}, {}, True),
+            (["messages.list"], {"@everyone": ["messages.list", "messages.create"]}, {}, {}, True),
+            (["messages.create"], {"@everyone": ["messages.list"]}, {}, {}, False),
             (
                 ["messages.create"],
-                {"@everyone": {"messages.list", "messages.create"}},
+                {"@everyone": ["messages.list", "messages.create"]},
                 {},
-                {"@everyone": {"messages.list"}},
+                {"@everyone": ["messages.list"]},
                 False,
             ),
             (
                 ["messages.create"],
-                {"@everyone": {"messages.list"}, "mod": {"messages.create", "messages.list", "members.kick"}},
+                {"@everyone": ["messages.list"], "mod": ["messages.create", "messages.list", "members.kick"]},
                 {},
                 {},
                 True,
             ),
             (
                 ["messages.create"],
-                {"@everyone": {"messages.list"}, "mod": {"messages.create", "messages.list", "members.kick"}},
+                {"@everyone": ["messages.list"], "mod": ["messages.create", "messages.list", "members.kick"]},
                 {},
-                {"mod": {"messages.list", "members.kick"}},
+                {"mod": ["messages.list", "members.kick"]},
                 False,
             ),
             (
                 ["messages.create"],
-                {"@everyone": set()},
-                {"@everyone": {"messages.list"}},
+                {"@everyone": []},
+                {"@everyone": ["messages.list"]},
                 {},
                 False,
             ),
             (
                 ["messages.create"],
-                {"@everyone": set()},
-                {"@everyone": {"messages.create"}},
+                {"@everyone": []},
+                {"@everyone": ["messages.create"]},
                 {},
                 True,
             ),
             (
                 ["messages.create"],
                 {"@everyone": {""}},
-                {"@everyone": {"messages.create"}},
-                {"@everyone": set()},
+                {"@everyone": ["messages.create"]},
+                {"@everyone": []},
                 False,
             ),
         ],
@@ -86,7 +86,7 @@ class TestPermissionsHelper:
         self, required, user_roles, channel_overwrites, section_overwrites, expected_result
     ):
         user_permissions = await _calc_final_permissions(
-            roles=user_roles, section_overwrites=section_overwrites, channel_overwrites=channel_overwrites
+            user_roles=user_roles, section_overwrites=section_overwrites, channel_overwrites=channel_overwrites
         )
         u_perms = list(user_permissions)
         calc_result = all([r_perm in u_perms for r_perm in required])

--- a/app/tests/helpers/test_permissions_helper.py
+++ b/app/tests/helpers/test_permissions_helper.py
@@ -1,7 +1,8 @@
 import pytest
 from bson import ObjectId
 
-from app.helpers.permissions import Permission, _calc_final_permissions, is_server_owner, needs, user_belongs_to_server
+from app.helpers.permissions import Permission, _calc_final_permissions, needs, user_belongs_to_server
+from app.helpers.servers import is_server_owner
 from app.models.channel import Channel
 from app.models.server import Server
 from app.models.user import User

--- a/app/tests/helpers/test_permissions_helper.py
+++ b/app/tests/helpers/test_permissions_helper.py
@@ -25,18 +25,18 @@ class TestPermissionsHelper:
     @pytest.mark.parametrize(
         "action_permissions, user_default_permissions, permission_overwrites, expected_result",
         [
-            (["messages.list"], {"default": ["messages.list", "messages.create"]}, {}, True),
-            (["messages.create"], {"default": ["messages.list"]}, {}, False),
+            (["messages.list"], {"@everyone": ["messages.list", "messages.create"]}, {}, True),
+            (["messages.create"], {"@everyone": ["messages.list"]}, {}, False),
             (
                 ["messages.create"],
-                {"default": ["messages.list", "messages.create"]},
-                {"default": ["messages.list"]},
+                {"@everyone": ["messages.list", "messages.create"]},
+                {"@everyone": ["messages.list"]},
                 False,
             ),
             (
                 ["messages.create"],
                 {
-                    "default": ["messages.list"],
+                    "@everyone": ["messages.list"],
                     "mod": ["messages.create", "messages.list", "members.kick"],
                 },
                 {},
@@ -45,7 +45,7 @@ class TestPermissionsHelper:
             (
                 ["messages.create"],
                 {
-                    "default": ["messages.list"],
+                    "@everyone": ["messages.list"],
                     "mod": ["messages.create", "messages.list", "members.kick"],
                 },
                 {"mod": ["messages.list", "members.kick"]},

--- a/app/tests/helpers/test_permissions_helper.py
+++ b/app/tests/helpers/test_permissions_helper.py
@@ -1,6 +1,8 @@
 import pytest
+from bson import ObjectId
 
-from app.helpers.permissions import has_permissions, user_belongs_to_server
+from app.helpers.permissions import Permission, _calc_final_permissions, is_server_owner, needs, user_belongs_to_server
+from app.models.channel import Channel
 from app.models.server import Server
 from app.models.user import User
 from app.services.servers import join_server
@@ -22,44 +24,123 @@ class TestPermissionsHelper:
         assert await user_belongs_to_server(user=guest_user, server_id=str(server.pk)) is True
 
     @pytest.mark.asyncio
+    async def test_user_is_server_owner(self, db, current_user: User, server: Server):
+        assert await is_server_owner(user=current_user, server_id=str(server.pk)) is True
+
+    @pytest.mark.asyncio
+    async def test_guest_user_is_not_server_owner(self, db, current_user: User, server: Server, guest_user: User):
+        assert await is_server_owner(user=guest_user, server_id=str(server.pk)) is False
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "action_permissions, user_default_permissions, permission_overwrites, expected_result",
+        "required, user_roles, section_overwrites, channel_overwrites, expected_result",
         [
-            (["messages.list"], {"@everyone": ["messages.list", "messages.create"]}, {}, True),
-            (["messages.create"], {"@everyone": ["messages.list"]}, {}, False),
+            (["messages.create"], {"@everyone": {"messages.create"}}, {}, {}, True),
+            (["messages.list"], {"@everyone": {"messages.list", "messages.create"}}, {}, {}, True),
+            (["messages.create"], {"@everyone": {"messages.list"}}, {}, {}, False),
             (
                 ["messages.create"],
-                {"@everyone": ["messages.list", "messages.create"]},
-                {"@everyone": ["messages.list"]},
+                {"@everyone": {"messages.list", "messages.create"}},
+                {},
+                {"@everyone": {"messages.list"}},
                 False,
             ),
             (
                 ["messages.create"],
-                {
-                    "@everyone": ["messages.list"],
-                    "mod": ["messages.create", "messages.list", "members.kick"],
-                },
+                {"@everyone": {"messages.list"}, "mod": {"messages.create", "messages.list", "members.kick"}},
+                {},
                 {},
                 True,
             ),
             (
                 ["messages.create"],
-                {
-                    "@everyone": ["messages.list"],
-                    "mod": ["messages.create", "messages.list", "members.kick"],
-                },
-                {"mod": ["messages.list", "members.kick"]},
+                {"@everyone": {"messages.list"}, "mod": {"messages.create", "messages.list", "members.kick"}},
+                {},
+                {"mod": {"messages.list", "members.kick"}},
+                False,
+            ),
+            (
+                ["messages.create"],
+                {"@everyone": set()},
+                {"@everyone": {"messages.list"}},
+                {},
+                False,
+            ),
+            (
+                ["messages.create"],
+                {"@everyone": set()},
+                {"@everyone": {"messages.create"}},
+                {},
+                True,
+            ),
+            (
+                ["messages.create"],
+                {"@everyone": {""}},
+                {"@everyone": {"messages.create"}},
+                {"@everyone": set()},
                 False,
             ),
         ],
     )
-    async def test_permissions_what(
-        self, action_permissions, user_default_permissions, permission_overwrites, expected_result
+    async def test_permission_calculations(
+        self, required, user_roles, channel_overwrites, section_overwrites, expected_result
     ):
-        has_permissions_result = await has_permissions(
-            action_permissions,
-            user_default_permissions,
-            overwrites=permission_overwrites,
+        user_permissions = await _calc_final_permissions(
+            roles=user_roles, section_overwrites=section_overwrites, channel_overwrites=channel_overwrites
         )
+        u_perms = list(user_permissions)
+        calc_result = all([r_perm in u_perms for r_perm in required])
+        assert calc_result == expected_result
 
-        assert has_permissions_result is expected_result
+    @pytest.mark.asyncio
+    async def test_permissions_decorator_no_current_user(self):
+        @needs(permissions=[Permission.MESSAGES_CREATE])
+        async def to_be_decorated():
+            pass
+
+        with pytest.raises(Exception) as exc_info:
+            await to_be_decorated()
+
+        assert "missing current_user" in exc_info.value.args[0]
+
+    @pytest.mark.asyncio
+    async def test_permissions_decorator_missing_channel_and_server(self, current_user: User):
+        @needs(permissions=[Permission.MESSAGES_CREATE])
+        async def to_be_decorated(user):
+            pass
+
+        with pytest.raises(Exception) as exc_info:
+            await to_be_decorated(current_user=current_user)
+
+        assert "no channel and server found" in exc_info.value.args[0]
+
+    @pytest.mark.asyncio
+    async def test_permissions_decorator_non_existing_channel(self, current_user: User):
+        @needs(permissions=[Permission.MESSAGES_CREATE])
+        async def to_be_decorated(user):
+            pass
+
+        with pytest.raises(Exception) as exc_info:
+            await to_be_decorated(current_user=current_user, channel_id=str(ObjectId()))
+
+        assert "need a server_id" in exc_info.value.args[0]
+
+    @pytest.mark.asyncio
+    async def test_permissions_decorator_ok(self, current_user: User, server_channel: Channel):
+        @needs(permissions=[Permission.MESSAGES_CREATE])
+        async def to_be_decorated(current_user: User = None, channel_id: str = ""):
+            assert current_user is not None
+            assert channel_id == str(server_channel.pk)
+            server = await server_channel.server.fetch()
+            assert current_user == server.owner
+
+        await to_be_decorated(current_user=current_user, channel_id=str(server_channel.pk))
+
+    @pytest.mark.asyncio
+    async def test_permissions_decorator_unknown_permission(self, current_user: User, server_channel: Channel):
+        @needs(permissions=["stuff.hack"])
+        async def to_be_decorated():
+            pass
+
+        with pytest.raises(AttributeError):
+            await to_be_decorated(current_user=current_user, channel_id=str(server_channel.pk))

--- a/app/tests/routers/test_channels.py
+++ b/app/tests/routers/test_channels.py
@@ -11,8 +11,11 @@ from app.models.channel import Channel
 from app.models.server import Server
 from app.models.user import User
 from app.schemas.channels import ServerChannelCreateSchema
+from app.schemas.messages import MessageCreateSchema
 from app.schemas.servers import ServerCreateSchema
+from app.services.channels import create_server_channel
 from app.services.crud import create_item
+from app.services.messages import create_message
 from app.services.servers import create_server
 
 
@@ -454,3 +457,50 @@ class TestChannelsRoutes:
                 assert last_read_at == default_ts
             else:
                 default_ts = last_read_at
+
+    @pytest.mark.asyncio
+    async def test_fetch_channel_messages(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+    ):
+        channel1_model = ServerChannelCreateSchema(kind="server", server=str(server.id), name="channel1")
+        channel1 = await create_server_channel(channel_model=channel1_model, current_user=current_user)
+
+        channel2_model = ServerChannelCreateSchema(kind="server", server=str(server.id), name="channel2")
+        channel2 = await create_server_channel(channel_model=channel2_model, current_user=current_user)
+
+        channel1_msgs = []
+        channel1_len = 3
+        for _ in range(channel1_len):
+            message_model = MessageCreateSchema(server=str(server.id), channel=str(channel1.pk), content="hey")
+            message = await create_message(message_model=message_model, current_user=current_user)
+            channel1_msgs.append(message)
+        channel1_msgs_ids = [str(msg.pk) for msg in channel1_msgs]
+
+        channel2_msgs = []
+        channel2_len = 1
+        for _ in range(channel2_len):
+            message_model = MessageCreateSchema(server=str(server.id), channel=str(channel2.pk), content="hey")
+            message = await create_message(message_model=message_model, current_user=current_user)
+            channel2_msgs.append(message)
+        channel2_msgs_ids = [str(msg.pk) for msg in channel2_msgs]
+
+        response = await authorized_client.get(f"/channels/{str(channel1.pk)}/messages")
+        assert response.status_code == 200
+        json_response = response.json()
+        assert len(response.json()) == channel1_len
+        resp_channels = [msg.get("channel") for msg in json_response]
+        assert all([channel_id == str(channel1.pk) for channel_id in resp_channels])
+        assert all([msg.get("id") in channel1_msgs_ids for msg in json_response])
+
+        response = await authorized_client.get(f"/channels/{str(channel2.pk)}/messages")
+        assert response.status_code == 200
+        json_response = response.json()
+        assert len(response.json()) == channel2_len
+        resp_channels = [msg.get("channel") for msg in json_response]
+        assert all([channel_id == str(channel2.pk) for channel_id in resp_channels])
+        assert all([msg.get("id") in channel2_msgs_ids for msg in json_response])

--- a/app/tests/routers/test_channels.py
+++ b/app/tests/routers/test_channels.py
@@ -105,6 +105,28 @@ class TestChannelsRoutes:
         assert json_response["server"] == str(server.id)
 
     @pytest.mark.asyncio
+    async def test_create_server_channel_not_belong_to_server(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        server: Server,
+        authorized_client: AsyncClient,
+        create_new_user: Callable,
+        get_authorized_client: Callable,
+    ):
+        data = {
+            "kind": "server",
+            "name": "fancy-announcements",
+            "server": str(server.id),
+        }
+        member = await create_new_user()
+        member_auth_client = await get_authorized_client(member)
+
+        response = await member_auth_client.post("/channels", json=data)
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
     async def test_create_server_channel_not_owner(
         self,
         app: FastAPI,
@@ -122,6 +144,9 @@ class TestChannelsRoutes:
         }
         member = await create_new_user()
         member_auth_client = await get_authorized_client(member)
+
+        response = await member_auth_client.post(f"/servers/{str(server.pk)}/join")
+        assert response.status_code == 201
 
         response = await member_auth_client.post("/channels", json=data)
         assert response.status_code == 403

--- a/app/tests/routers/test_messages.py
+++ b/app/tests/routers/test_messages.py
@@ -895,6 +895,10 @@ class TestMessagesRoutes:
     ):
         guest_user = await create_new_user()
         guest_client = await get_authorized_client(guest_user)
+
+        response = await guest_client.post(f"/servers/{str(server.pk)}/join")
+        assert response.status_code == 201
+
         data = {
             "blocks": [
                 {
@@ -942,6 +946,10 @@ class TestMessagesRoutes:
     ):
         guest_user = await create_new_user()
         guest_client = await get_authorized_client(guest_user)
+
+        response = await guest_client.post(f"/servers/{str(server.pk)}/join")
+        assert response.status_code == 201
+
         data = {
             "blocks": [
                 {

--- a/app/tests/routers/test_permissions.py
+++ b/app/tests/routers/test_permissions.py
@@ -1,4 +1,4 @@
-from typing import Callable, List
+from typing import Callable, Dict, List
 
 import pytest
 from fastapi import FastAPI
@@ -6,8 +6,10 @@ from httpx import AsyncClient
 from pymongo.database import Database
 
 from app.models.channel import Channel
+from app.models.section import Section
 from app.models.server import Server, ServerMember
 from app.models.user import Role, User
+from app.schemas.sections import SectionCreateSchema
 from app.schemas.users import RoleCreateSchema
 from app.services.crud import create_item, get_item, update_item
 
@@ -118,4 +120,224 @@ class TestPermissionsRoutes:
 
         data = {"kind": "server", "name": "fancy-announcements", "server": str(server.id)}
         response = await guest_client.post("/channels", json=data)
+        assert response.status_code == status
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "role_permissions, channel_overwrites, status",
+        [
+            (["messages.list"], None, 200),
+            (["messages.list"], [], 403),
+            (["messages.list"], ["messages.create"], 403),
+            (["messages.list"], ["messages.create", "messages.list"], 200),
+            (["messages.create"], ["messages.create"], 403),
+            (["messages.create"], None, 403),
+            (["channels.view"], ["messages.list"], 200),
+        ],
+    )
+    async def test_fetch_messages_as_guest_with_channel_overwrites(
+        self,
+        app: FastAPI,
+        db: Database,
+        guest_user: User,
+        get_authorized_client: Callable,
+        server: Server,
+        server_channel: Channel,
+        role_permissions: List[str],
+        status: int,
+        channel_overwrites: List[str],
+    ):
+        default_role = "@everyone"
+        role_schema = RoleCreateSchema(name=default_role, server=str(server.pk), permissions=role_permissions)
+        role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+        guest_client = await get_authorized_client(guest_user)
+        response = await guest_client.post(f"/servers/{str(server.pk)}/join")
+        assert response.status_code == 201
+
+        member = await get_item(
+            filters={"server": server.pk, "user": guest_user.pk}, result_obj=ServerMember, current_user=guest_user
+        )
+        assert member is not None
+        await update_item(item=member, data={"roles": [role]}, current_user=guest_user)
+
+        if channel_overwrites is not None:
+            data = {"permission_overwrites": [{"role": role.pk, "permissions": channel_overwrites}]}
+            await update_item(item=server_channel, data=data, current_user=guest_user)
+
+        response = await guest_client.get(f"/channels/{str(server_channel.id)}/messages")
+        assert response.status_code == status
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "role_permissions, section_overwrites, status",
+        [
+            (["messages.list"], None, 200),
+            (["messages.list"], [], 403),
+            (["messages.list"], ["messages.create"], 403),
+            (["messages.list"], ["messages.create", "messages.list"], 200),
+            (["messages.create"], ["messages.create"], 403),
+            (["messages.create"], None, 403),
+            (["channels.view"], ["messages.list"], 200),
+        ],
+    )
+    async def test_fetch_messages_as_guest_with_section_overwrites(
+        self,
+        app: FastAPI,
+        db: Database,
+        guest_user: User,
+        get_authorized_client: Callable,
+        server: Server,
+        server_channel: Channel,
+        role_permissions: List[str],
+        status: int,
+        section_overwrites: List[str],
+    ):
+        default_role = "@everyone"
+        role_schema = RoleCreateSchema(name=default_role, server=str(server.pk), permissions=role_permissions)
+        role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+        guest_client = await get_authorized_client(guest_user)
+        response = await guest_client.post(f"/servers/{str(server.pk)}/join")
+        assert response.status_code == 201
+
+        member = await get_item(
+            filters={"server": server.pk, "user": guest_user.pk}, result_obj=ServerMember, current_user=guest_user
+        )
+        assert member is not None
+        await update_item(item=member, data={"roles": [role]}, current_user=guest_user)
+
+        if section_overwrites is not None:
+            section_model = SectionCreateSchema(
+                name="who-cares", channels=[str(server_channel.pk)], server=str(server.pk)
+            )
+            section = await create_item(section_model, result_obj=Section, current_user=guest_user, user_field=None)
+            data = {"permission_overwrites": [{"role": role.pk, "permissions": section_overwrites}]}
+            await update_item(item=section, data=data, current_user=guest_user)
+
+        response = await guest_client.get(f"/channels/{str(server_channel.id)}/messages")
+        assert response.status_code == status
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "role_permissions, section_overwrites, channel_overwrites, status",
+        [
+            (["messages.list"], None, None, 200),
+            (["messages.list"], [], None, 403),
+            (["messages.list"], None, [], 403),
+            ([], ["messages.list"], None, 200),
+            ([], None, ["messages.list"], 200),
+            (["messages.list"], [], ["messages.list"], 200),
+            ([], ["messages.list"], None, 200),
+            ([], None, ["messages.list"], 200),
+            ([], ["messages.list"], [], 403),
+        ],
+    )
+    async def test_fetch_messages_as_guest_with_channel_and_section_overwrites(
+        self,
+        app: FastAPI,
+        db: Database,
+        guest_user: User,
+        get_authorized_client: Callable,
+        server: Server,
+        server_channel: Channel,
+        role_permissions: List[str],
+        status: int,
+        section_overwrites: List[str],
+        channel_overwrites: List[str],
+    ):
+        default_role = "@everyone"
+        role_schema = RoleCreateSchema(name=default_role, server=str(server.pk), permissions=role_permissions)
+        role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+        guest_client = await get_authorized_client(guest_user)
+        response = await guest_client.post(f"/servers/{str(server.pk)}/join")
+        assert response.status_code == 201
+
+        member = await get_item(
+            filters={"server": server.pk, "user": guest_user.pk}, result_obj=ServerMember, current_user=guest_user
+        )
+        assert member is not None
+        await update_item(item=member, data={"roles": [role]}, current_user=guest_user)
+
+        if section_overwrites is not None:
+            section_model = SectionCreateSchema(
+                name="who-cares", channels=[str(server_channel.pk)], server=str(server.pk)
+            )
+            section = await create_item(section_model, result_obj=Section, current_user=guest_user, user_field=None)
+            data = {"permission_overwrites": [{"role": role.pk, "permissions": section_overwrites}]}
+            await update_item(item=section, data=data, current_user=guest_user)
+
+        if channel_overwrites is not None:
+            data = {"permission_overwrites": [{"role": role.pk, "permissions": channel_overwrites}]}
+            await update_item(item=server_channel, data=data, current_user=guest_user)
+
+        response = await guest_client.get(f"/channels/{str(server_channel.id)}/messages")
+        assert response.status_code == status
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "role_permissions, section_overwrites, channel_overwrites, status",
+        [
+            ({"guest": ["messages.list"]}, None, None, 200),
+            ({"guest": []}, None, None, 403),
+            ({"guest": [], "mod": ["messages.list"]}, None, None, 200),
+            ({"guest": []}, {"guest": ["messages.list"]}, None, 200),
+            ({"guest": [], "mod": ["messages.list"]}, {"mod": []}, None, 403),
+            ({"guest": [], "mod": []}, {"mod": ["messages.list"]}, None, 200),
+            ({"guest": [], "mod": []}, None, {"mod": ["messages.list"]}, 200),
+            ({"guest": [], "mod": ["messages.list"]}, None, {"mod": []}, 403),
+            ({"guest": [], "mod": []}, {"mod": ["messages.list"]}, {"mod": []}, 403),
+            ({"guest": [], "mod": []}, {"guest": ["messages.list"], "mod": ["messages.list"]}, {"guest": []}, 200),
+        ],
+    )
+    async def test_fetch_messages_as_guest_with_channel_and_section_overwrites_multiple_roles(
+        self,
+        app: FastAPI,
+        db: Database,
+        guest_user: User,
+        get_authorized_client: Callable,
+        server: Server,
+        server_channel: Channel,
+        role_permissions: Dict[str, List[str]],
+        status: int,
+        section_overwrites: Dict[str, List[str]],
+        channel_overwrites: Dict[str, List[str]],
+    ):
+        roles = []
+        for role_name, permissions in role_permissions.items():
+            role_schema = RoleCreateSchema(name=role_name, server=str(server.pk), permissions=permissions)
+            role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+            roles.append(role)
+
+        guest_client = await get_authorized_client(guest_user)
+        response = await guest_client.post(f"/servers/{str(server.pk)}/join")
+        assert response.status_code == 201
+
+        member = await get_item(
+            filters={"server": server.pk, "user": guest_user.pk}, result_obj=ServerMember, current_user=guest_user
+        )
+        assert member is not None
+        await update_item(item=member, data={"roles": [role.pk for role in roles]}, current_user=guest_user)
+
+        if section_overwrites is not None:
+            section_model = SectionCreateSchema(
+                name="who-cares", channels=[str(server_channel.pk)], server=str(server.pk)
+            )
+            section = await create_item(section_model, result_obj=Section, current_user=guest_user, user_field=None)
+
+            ow = []
+            for s_role_name, s_role_permissions in section_overwrites.items():
+                role = await get_item(filters={"name": s_role_name, "server": server.pk}, result_obj=Role)
+                ow.append({"role": role.pk, "permissions": s_role_permissions})
+            data = {"permission_overwrites": ow}
+
+            await update_item(item=section, data=data, current_user=guest_user)
+
+        if channel_overwrites is not None:
+            ow = []
+            for c_role_name, c_role_permissions in channel_overwrites.items():
+                role = await get_item(filters={"name": c_role_name, "server": server.pk}, result_obj=Role)
+                ow.append({"role": role.pk, "permissions": c_role_permissions})
+            data = {"permission_overwrites": ow}
+            await update_item(item=server_channel, data=data, current_user=guest_user)
+
+        response = await guest_client.get(f"/channels/{str(server_channel.id)}/messages")
         assert response.status_code == status

--- a/app/tests/routers/test_permissions.py
+++ b/app/tests/routers/test_permissions.py
@@ -12,6 +12,7 @@ from app.models.user import Role, User
 from app.schemas.sections import SectionCreateSchema
 from app.schemas.users import RoleCreateSchema
 from app.services.crud import create_item, get_item, update_item
+from app.services.roles import create_role
 
 
 class TestPermissionsRoutes:
@@ -37,7 +38,9 @@ class TestPermissionsRoutes:
         status: int,
     ):
         role_schema = RoleCreateSchema(name="test", server=str(server.pk), permissions=permissions)
-        role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+        role = await create_role(
+            server_id=str(server.pk), role_model=role_schema, current_user=guest_user, ignore_permissions=True
+        )
         guest_client = await get_authorized_client(guest_user)
         response = await guest_client.post(f"/servers/{str(server.pk)}/join")
         assert response.status_code == 201
@@ -73,7 +76,9 @@ class TestPermissionsRoutes:
         status: int,
     ):
         role_schema = RoleCreateSchema(name="test", server=str(server.pk), permissions=permissions)
-        role = await create_item(item=role_schema, result_obj=Role, current_user=current_user, user_field=None)
+        role = await create_role(
+            server_id=str(server.pk), role_model=role_schema, current_user=current_user, ignore_permissions=True
+        )
 
         member = await get_item(
             filters={"server": server.pk, "user": current_user.pk}, result_obj=ServerMember, current_user=current_user
@@ -107,7 +112,9 @@ class TestPermissionsRoutes:
         status: int,
     ):
         role_schema = RoleCreateSchema(name="test", server=str(server.pk), permissions=permissions)
-        role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+        role = await create_role(
+            server_id=str(server.pk), role_model=role_schema, current_user=guest_user, ignore_permissions=True
+        )
         guest_client = await get_authorized_client(guest_user)
         response = await guest_client.post(f"/servers/{str(server.pk)}/join")
         assert response.status_code == 201
@@ -149,7 +156,9 @@ class TestPermissionsRoutes:
     ):
         default_role = "@everyone"
         role_schema = RoleCreateSchema(name=default_role, server=str(server.pk), permissions=role_permissions)
-        role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+        role = await create_role(
+            server_id=str(server.pk), role_model=role_schema, current_user=guest_user, ignore_permissions=True
+        )
         guest_client = await get_authorized_client(guest_user)
         response = await guest_client.post(f"/servers/{str(server.pk)}/join")
         assert response.status_code == 201
@@ -194,7 +203,9 @@ class TestPermissionsRoutes:
     ):
         default_role = "@everyone"
         role_schema = RoleCreateSchema(name=default_role, server=str(server.pk), permissions=role_permissions)
-        role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+        role = await create_role(
+            server_id=str(server.pk), role_model=role_schema, current_user=guest_user, ignore_permissions=True
+        )
         guest_client = await get_authorized_client(guest_user)
         response = await guest_client.post(f"/servers/{str(server.pk)}/join")
         assert response.status_code == 201
@@ -246,7 +257,9 @@ class TestPermissionsRoutes:
     ):
         default_role = "@everyone"
         role_schema = RoleCreateSchema(name=default_role, server=str(server.pk), permissions=role_permissions)
-        role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+        role = await create_role(
+            server_id=str(server.pk), role_model=role_schema, current_user=guest_user, ignore_permissions=True
+        )
         guest_client = await get_authorized_client(guest_user)
         response = await guest_client.post(f"/servers/{str(server.pk)}/join")
         assert response.status_code == 201
@@ -304,7 +317,9 @@ class TestPermissionsRoutes:
         roles = []
         for role_name, permissions in role_permissions.items():
             role_schema = RoleCreateSchema(name=role_name, server=str(server.pk), permissions=permissions)
-            role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+            role = await create_role(
+                server_id=str(server.pk), role_model=role_schema, current_user=guest_user, ignore_permissions=True
+            )
             roles.append(role)
 
         guest_client = await get_authorized_client(guest_user)

--- a/app/tests/routers/test_permissions.py
+++ b/app/tests/routers/test_permissions.py
@@ -1,0 +1,121 @@
+from typing import Callable, List
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+from pymongo.database import Database
+
+from app.models.channel import Channel
+from app.models.server import Server, ServerMember
+from app.models.user import Role, User
+from app.schemas.users import RoleCreateSchema
+from app.services.crud import create_item, get_item, update_item
+
+
+class TestPermissionsRoutes:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "permissions, status",
+        [
+            (["messages.list"], 200),
+            (["messages.create", "members.kick"], 403),
+            ([], 403),
+            (["messages.list", "members.kick", "members.ban"], 200),
+        ],
+    )
+    async def test_fetch_messages_as_guest(
+        self,
+        app: FastAPI,
+        db: Database,
+        guest_user: User,
+        get_authorized_client: Callable,
+        server: Server,
+        server_channel: Channel,
+        permissions: List[str],
+        status: int,
+    ):
+        role_schema = RoleCreateSchema(name="test", server=str(server.pk), permissions=permissions)
+        role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+        guest_client = await get_authorized_client(guest_user)
+        response = await guest_client.post(f"/servers/{str(server.pk)}/join")
+        assert response.status_code == 201
+
+        member = await get_item(
+            filters={"server": server.pk, "user": guest_user.pk}, result_obj=ServerMember, current_user=guest_user
+        )
+        assert member is not None
+        await update_item(item=member, data={"roles": [role]}, current_user=guest_user)
+
+        response = await guest_client.get(f"/channels/{str(server_channel.id)}/messages")
+        assert response.status_code == status
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "permissions, status",
+        [
+            (["messages.list"], 200),
+            (["messages.create", "members.kick"], 200),
+            ([], 200),
+            (["messages.list", "members.kick", "members.ban"], 200),
+        ],
+    )
+    async def test_fetch_messages_as_server_owner(
+        self,
+        app: FastAPI,
+        db: Database,
+        current_user: User,
+        authorized_client: AsyncClient,
+        server: Server,
+        server_channel: Channel,
+        permissions: List[str],
+        status: int,
+    ):
+        role_schema = RoleCreateSchema(name="test", server=str(server.pk), permissions=permissions)
+        role = await create_item(item=role_schema, result_obj=Role, current_user=current_user, user_field=None)
+
+        member = await get_item(
+            filters={"server": server.pk, "user": current_user.pk}, result_obj=ServerMember, current_user=current_user
+        )
+        assert member is not None
+        await update_item(item=member, data={"roles": [role]}, current_user=current_user)
+
+        response = await authorized_client.get(f"/channels/{str(server_channel.id)}/messages")
+        assert response.status_code == status
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "permissions, status",
+        [
+            ([], 403),
+            (["messages.list"], 403),
+            (["messages.create", "members.kick"], 403),
+            (["messages.list", "members.kick", "members.ban"], 403),
+            (["messages.list", "messages.create", "channels.create"], 201),
+        ],
+    )
+    async def test_create_channel_as_guest(
+        self,
+        app: FastAPI,
+        db: Database,
+        guest_user: User,
+        get_authorized_client: Callable,
+        server: Server,
+        server_channel: Channel,
+        permissions: List[str],
+        status: int,
+    ):
+        role_schema = RoleCreateSchema(name="test", server=str(server.pk), permissions=permissions)
+        role = await create_item(item=role_schema, result_obj=Role, current_user=guest_user, user_field=None)
+        guest_client = await get_authorized_client(guest_user)
+        response = await guest_client.post(f"/servers/{str(server.pk)}/join")
+        assert response.status_code == 201
+
+        member = await get_item(
+            filters={"server": server.pk, "user": guest_user.pk}, result_obj=ServerMember, current_user=guest_user
+        )
+        assert member is not None
+        await update_item(item=member, data={"roles": [role]}, current_user=guest_user)
+
+        data = {"kind": "server", "name": "fancy-announcements", "server": str(server.id)}
+        response = await guest_client.post("/channels", json=data)
+        assert response.status_code == status

--- a/app/tests/routers/test_roles.py
+++ b/app/tests/routers/test_roles.py
@@ -1,0 +1,37 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+from pymongo.database import Database
+
+from app.helpers.cache_utils import cache
+from app.helpers.permissions import Permission
+from app.models.server import Server
+from app.models.user import User
+
+
+class TestRoleRoutes:
+    @pytest.mark.asyncio
+    async def test_create_role(
+        self, app: FastAPI, db: Database, current_user: User, authorized_client: AsyncClient, server: Server
+    ):
+        response = await authorized_client.get(f"/servers/{str(server.pk)}/roles")
+        assert response.status_code == 200
+        json_resp = response.json()
+        assert len(json_resp) == 1
+        assert json_resp[0]["name"] == "@everyone"
+
+        new_role = {"name": "mod", "permissions": [Permission.MEMBERS_KICK.value]}
+
+        response = await authorized_client.post(f"/servers/{str(server.pk)}/roles", json=new_role)
+        assert response.status_code == 201
+
+        response = await authorized_client.get(f"/servers/{str(server.pk)}/roles")
+        assert response.status_code == 200
+        json_resp = response.json()
+        assert len(json_resp) == 2
+        assert json_resp[0]["name"] == new_role["name"]
+        resp_roles = {role["id"]: ",".join(role["permissions"]) for role in json_resp}
+
+        for role, perms in resp_roles.items():
+            cached_perms = await cache.client.hget(f"server:{str(server.pk)}", f"roles.{role}")
+            assert cached_perms == perms

--- a/app/tests/routers/test_sections.py
+++ b/app/tests/routers/test_sections.py
@@ -43,7 +43,7 @@ class TestSectionRoutes:
         channels = []
         for channel_name in ch_names:
             channel = await create_server_channel(
-                ServerChannelCreateSchema(kind="server", server=str(server.id), name=channel_name),
+                channel_model=ServerChannelCreateSchema(kind="server", server=str(server.id), name=channel_name),
                 current_user=current_user,
             )
             channels.append(channel)
@@ -70,7 +70,7 @@ class TestSectionRoutes:
         channels = []
         for channel_name in ch_names:
             channel = await create_server_channel(
-                ServerChannelCreateSchema(kind="server", server=str(server.id), name=channel_name),
+                channel_model=ServerChannelCreateSchema(kind="server", server=str(server.id), name=channel_name),
                 current_user=current_user,
             )
             channels.append(channel)

--- a/app/tests/routers/test_servers.py
+++ b/app/tests/routers/test_servers.py
@@ -401,7 +401,7 @@ class TestServerRoutes:
         self, app: FastAPI, db: Database, current_user: User, authorized_client: AsyncClient, server: Server
     ):
         channel_model = ServerChannelCreateSchema(kind="server", server=str(server.id), name="entrance")
-        channel = await create_server_channel(channel_model, current_user=current_user)
+        channel = await create_server_channel(channel_model=channel_model, current_user=current_user)
 
         patch_data = {"system_channel": str(channel.pk)}
         response = await authorized_client.patch(f"/servers/{str(server.pk)}", json=patch_data)
@@ -417,7 +417,7 @@ class TestServerRoutes:
         other_server_model = ServerCreateSchema(name="Other")
         other_server = await create_server(other_server_model, current_user=current_user)
         channel_model = ServerChannelCreateSchema(kind="server", server=str(other_server.id), name="entrance")
-        channel = await create_server_channel(channel_model, current_user=current_user)
+        channel = await create_server_channel(channel_model=channel_model, current_user=current_user)
 
         patch_data = {"system_channel": str(channel.pk)}
         response = await authorized_client.patch(f"/servers/{str(server.pk)}", json=patch_data)
@@ -471,7 +471,7 @@ class TestServerRoutes:
         channels = []
         for i in range(10):
             channel = await create_server_channel(
-                ServerChannelCreateSchema(kind="server", server=str(server.id), name=f"channel-{i}"),
+                channel_model=ServerChannelCreateSchema(kind="server", server=str(server.id), name=f"channel-{i}"),
                 current_user=current_user,
             )
             channels.append(channel)
@@ -500,7 +500,7 @@ class TestServerRoutes:
         channels = []
         for i in range(10):
             channel = await create_server_channel(
-                ServerChannelCreateSchema(kind="server", server=str(server.id), name=f"channel-{i}"),
+                channel_model=ServerChannelCreateSchema(kind="server", server=str(server.id), name=f"channel-{i}"),
                 current_user=current_user,
             )
             channels.append(channel)


### PR DESCRIPTION
This implementation was heavily inspired by discord's customizable role-based permissions, with a touch more of simplicity and user-friendliness.

The main flow is:
- A server/community defines roles and their default permissions
- Members can be assigned one or multiple roles
- Each section and channel can have specific permissions to overwrite the role's defaults


The key differences with discord's implementation are:
1. the use of pure-text scopes (`messages.list`) rather than hex descriptors (`0x80...`)
2. simpler storage of permissions' inheritance across different resources (server, sections, and channels)

---

To be done (on diff PRs):
- Additional API endpoints are needed to assign roles to members, update roles' permissions, add overwrites to channels/sections, etc.
- Update `/ready` request to hide private data
- Add permissions to more API calls