### PR TITLE
App authentication using OAuth2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.3.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -9,7 +9,7 @@ repos:
       - id: check-ast
       - id: check-builtin-literals
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
@@ -18,13 +18,14 @@ repos:
       - id: isort
         name: isort (python)
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
+        args: [--py3-plus]
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:
@@ -33,7 +34,7 @@ repos:
       - id: python-no-eval
       - id: python-no-log-warn
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.971
     hooks:
       - id: mypy
         additional_dependencies: [types-requests==2.27.9,types-redis==4.2.0]

--- a/app/config.py
+++ b/app/config.py
@@ -8,9 +8,11 @@ class Settings(BaseSettings):
     testing: bool = True
     profiling: bool = False
     profiling_json: bool = False
+    environment: str = "development"
+
+    frontend_url: str = "http://localhost:8080"
     cdn_url: str = "https://cdn.newshades.xyz"
     cdn_media_folder: str = "media"
-    environment: str = "development"
 
     mongodb_url: str = "localhost:27017"
     mongodb_db: str = "newshades"

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -33,6 +33,8 @@ async def get_current_client(request: Request, credentials: HTTPBasicCredentials
     client_secret = credentials.password
     app: App = await get_app_by_client_id(client_id)
 
+    request.state.auth_type = "basic"
+
     if not app:
         logger.warning("Client not found. [client_id=%s]", client_id)
         raise credentials_exception
@@ -94,7 +96,8 @@ async def get_current_app(request: Request, token: HTTPAuthorizationCredentials 
         sub: str = payload.get("sub")
         if not sub:
             raise credentials_exception
-    except JWTError:
+    except JWTError as e:
+        logger.debug(f"jwt error: {e}")
         raise credentials_exception
     except Exception:
         logger.exception("Problems decoding JWT. [jwt=%s]", token.credentials)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -67,8 +67,8 @@ async def get_current_user_non_error(
 
 
 class PermissionsChecker:
-    def __init__(self, needs_user: bool = True, permissions: List[str] = None):
-        self.needs_user = needs_user
+    def __init__(self, needs_bearer: bool = True, permissions: List[str] = None):
+        self.needs_bearer = needs_bearer
         self.permissions = permissions
 
     async def __call__(
@@ -77,7 +77,7 @@ class PermissionsChecker:
         if isinstance(user_or_exception, Exception):
             raise user_or_exception
 
-        if self.needs_user and user_or_exception is None:
+        if self.needs_bearer and user_or_exception is None:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Could not validate token",

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -10,11 +10,14 @@ from starlette.requests import Request
 from app.helpers.cache_utils import cache
 from app.helpers.jwt import decode_jwt_token
 from app.helpers.permissions import check_request_permissions
+from app.models.app import App
 from app.models.user import User
+from app.services.apps import get_app_by_client_id
 from app.services.users import get_user_by_id
 
 oauth2_scheme = HTTPBearer()
 oauth2_no_error_scheme = HTTPBearer(auto_error=False)
+
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +39,13 @@ async def get_current_user(request: Request, token: HTTPAuthorizationCredentials
         logger.exception("Problems decoding JWT. [jwt=%s]", token.credentials)
         raise credentials_exception
 
-    user = await get_user_by_id(user_id=user_id)
+    request.state.auth_type = "bearer"
+
+    client_id: str = payload.get("client_id")
+    if client_id:
+        return None
+
+    user: User = await get_user_by_id(user_id=user_id)
     if not user:
         logger.warning("User in JWT token not found. [user_id=%s]", user_id)
         raise credentials_exception
@@ -46,11 +55,53 @@ async def get_current_user(request: Request, token: HTTPAuthorizationCredentials
         raise credentials_exception
 
     request.state.user_id = user_id
-    request.state.auth_type = "bearer"
-
-    set_user({"id": user_id})
-
+    request.state.actor_type = "user"
+    request.state.auth_source = "wallet"
+    set_user({"id": user_id, "type": "user"})
     return user
+
+
+async def get_current_app(request: Request, token: HTTPAuthorizationCredentials = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate token",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = decode_jwt_token(token.credentials)
+        sub: str = payload.get("sub")
+        if not sub:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    except Exception:
+        logger.exception("Problems decoding JWT. [jwt=%s]", token.credentials)
+        raise credentials_exception
+
+    request.state.auth_type = "bearer"
+    client_id: str = payload.get("client_id")
+    if not client_id:
+        return None
+
+    app: App = await get_app_by_client_id(client_id)
+    if str(app.pk) != sub:
+        raise credentials_exception
+
+    if not app:
+        logger.warning("App in JWT token not found. [app_id=%s]", sub)
+        raise credentials_exception
+
+    if not await cache.client.smembers(f"refresh_tokens:{str(app.pk)}"):
+        logger.warning("Refresh tokens have all been revoked. [app_id=%s]", sub)
+        raise credentials_exception
+
+    request.state.app_id = sub
+    request.state.actor_type = "app"
+    request.state.auth_source = "oauth2"
+    request.state.scopes = payload.get("scopes", [])
+
+    set_user({"id": str(app.pk), "name": app.name, "type": "app", "client_id": client_id})
+    return app
 
 
 async def get_current_user_non_error(
@@ -66,18 +117,37 @@ async def get_current_user_non_error(
         return e
 
 
+async def get_current_app_non_error(
+    request: Request, token: HTTPAuthorizationCredentials = Depends(oauth2_no_error_scheme)
+):
+    if not token:
+        return None
+
+    try:
+        current_app = await get_current_app(request, token)
+        return current_app
+    except Exception as e:
+        return e
+
+
 class PermissionsChecker:
     def __init__(self, needs_bearer: bool = True, permissions: List[str] = None):
         self.needs_bearer = needs_bearer
         self.permissions = permissions
 
     async def __call__(
-        self, request: Request, user_or_exception: Union[User, Exception, None] = Depends(get_current_user_non_error)
+        self,
+        request: Request,
+        user_or_exception: Union[User, Exception, None] = Depends(get_current_user_non_error),
+        app_or_exception: Union[App, Exception, None] = Depends(get_current_app_non_error),
     ):
         if isinstance(user_or_exception, Exception):
             raise user_or_exception
 
-        if self.needs_bearer and user_or_exception is None:
+        if isinstance(app_or_exception, Exception):
+            raise app_or_exception
+
+        if self.needs_bearer and user_or_exception is None and app_or_exception is None:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Could not validate token",
@@ -86,7 +156,11 @@ class PermissionsChecker:
 
         if self.permissions:
             user = cast(User, user_or_exception)
-            await check_request_permissions(request=request, current_user=user, permissions=self.permissions)
+            app = cast(App, app_or_exception)
+
+            await check_request_permissions(
+                request=request, current_user=user, current_app=app, permissions=self.permissions
+            )
 
 
 async def common_parameters(

--- a/app/helpers/apps.py
+++ b/app/helpers/apps.py
@@ -1,0 +1,32 @@
+from bson import ObjectId
+
+from app.helpers.cache_utils import cache
+from app.models.app import App, AppInstalled
+from app.services.crud import get_item_by_id, get_items
+
+
+async def fetch_and_cache_app(app_id: str):
+    if not app_id:
+        return {}
+
+    app = await get_item_by_id(id_=app_id, result_obj=App)
+    if not app:
+        return {}
+
+    installations = await get_items(filters={"app": ObjectId(app_id)}, result_obj=AppInstalled)
+
+    dict_app = {
+        "id": app_id,
+        "creator": str(app.creator.pk),
+    }
+
+    channel_ids = []
+    for installation in installations:
+        channel_id = str(installation.channel.pk)
+        channel_ids.append(channel_id)
+        dict_app[f"channel:{channel_id}"] = " ".join(installation.scopes)
+
+    dict_app["channels"] = ",".join(channel_ids)
+
+    await cache.client.hset(f"app:{app_id}", mapping=dict_app)
+    return dict_app

--- a/app/helpers/apps.py
+++ b/app/helpers/apps.py
@@ -24,7 +24,7 @@ async def fetch_and_cache_app(app_id: str):
     for installation in installations:
         channel_id = str(installation.channel.pk)
         channel_ids.append(channel_id)
-        dict_app[f"channel:{channel_id}"] = " ".join(installation.scopes)
+        dict_app[f"channel:{channel_id}"] = ",".join(installation.scopes)
 
     dict_app["channels"] = ",".join(channel_ids)
 

--- a/app/helpers/auth.py
+++ b/app/helpers/auth.py
@@ -24,8 +24,10 @@ from app.models.channel import Channel
 from app.models.user import User
 from app.schemas.apps import AppInstalledCreateSchema
 from app.schemas.auth import AuthorizationCodeCreateSchema
+from app.schemas.messages import AppInstallMessageCreateSchema
 from app.services.apps import get_app_by_client_id
 from app.services.crud import create_item, delete_item, get_item, get_item_by_id, get_items
+from app.services.messages import create_app_message
 
 logger = logging.getLogger(__name__)
 
@@ -205,10 +207,10 @@ class Storage(BaseStorage):
             new_install = await create_item(item=install_model, current_user=request.user, result_obj=AppInstalled)
 
             logger.debug("New app installed: %s", new_install)
-
-            # # TODO: create app joined channel message
-            # message = AppMessageCreateSchema(channel=channel_id, app=str(app.pk))
-            # await create_app_message(message_model=message)
+            message = AppInstallMessageCreateSchema(
+                channel=channel_id, app=str(app.pk), installer=str(request.user.pk), type=6
+            )
+            await create_app_message(message_model=message)
 
         token = Token(
             client_id=client_id,

--- a/app/helpers/auth.py
+++ b/app/helpers/auth.py
@@ -1,0 +1,144 @@
+import time
+from typing import Optional
+
+from aioauth.config import Settings
+from aioauth.models import AuthorizationCode, Client, Token
+from aioauth.requests import Request
+from aioauth.server import AuthorizationServer
+from aioauth.storage import BaseStorage
+from aioauth.types import GrantType, ResponseType, TokenType
+from fastapi import Form, Query
+
+from app.config import get_settings
+from app.helpers.jwt import generate_jwt_token
+from app.models.app import App
+from app.models.user import User
+from app.services.apps import get_app_by_client_id
+from app.services.crud import get_item
+
+
+class Storage(BaseStorage):
+    """
+    Storage methods must be implemented here.
+    """
+
+    async def get_token(
+        self,
+        request: Request,
+        client_id: str,
+        token_type: Optional[str] = TokenType.REFRESH,
+        access_token: Optional[str] = None,
+        refresh_token: Optional[str] = None,
+    ) -> Optional[Token]:
+        pass
+
+    async def authenticate(self, request: Request) -> bool:
+        pass
+
+    async def revoke_token(self, request: Request, refresh_token: str) -> None:
+        pass
+
+    async def get_client(
+        self, request: Request, client_id: str, client_secret: Optional[str] = None
+    ) -> Optional[Client]:
+        app: App = await get_app_by_client_id(client_id=client_id)
+        if not app:
+            return None
+
+        return Client(
+            client_id=app.client_id,
+            client_secret=app.client_secret,
+            redirect_uris=app.redirect_uris,
+            grant_types=[GrantType.TYPE_AUTHORIZATION_CODE, GrantType.TYPE_REFRESH_TOKEN],
+            response_types=[ResponseType.TYPE_CODE],
+            user=app.creator,
+        )
+
+    async def get_authorization_code(self, request: Request, client_id: str, code: str) -> Optional[AuthorizationCode]:
+        # TODO: fix this
+        default_user = await get_item(filters={}, result_obj=User)
+        app: App = await get_app_by_client_id(client_id=client_id)
+        if not app:
+            return None
+
+        auth_code = AuthorizationCode(
+            code=code,
+            client_id=client_id,
+            redirect_uri=request.query.redirect_uri,
+            response_type=ResponseType.TYPE_CODE,
+            auth_time=int(time.time()) - 5,
+            expires_in=300,
+            user=default_user,
+            scope=request.query.scope,
+        )
+        return auth_code
+
+    async def delete_authorization_code(self, request: Request, client_id: str, code: str) -> None:
+        # TODO: delete codes...
+        return
+
+    async def create_token(self, request: Request, client_id: str, scope: str, *args) -> Token:
+        app_settings = get_settings()
+        app: App = await get_app_by_client_id(client_id=client_id)
+        access_token = generate_jwt_token({"sub": str(app.pk), "client_id": client_id})
+        refresh_token = generate_jwt_token({"sub": str(app.pk)}, token_type="refresh")
+
+        # TODO: add caching
+        # await cache.client.sadd(f"refresh_tokens:{str(app.pk)}", refresh_token)
+        # await create_item(
+        #     RefreshTokenCreateSchema(refresh_token=refresh_token, app=str(app.pk)),
+        #     result_obj=RefreshToken,
+        #     user_field="app",
+        #     current_user=app,
+        # )
+
+        token = Token(
+            client_id=client_id,
+            expires_in=app_settings.jwt_access_token_expire_minutes,
+            refresh_token_expires_in=app_settings.jwt_refresh_token_expire_minutes,
+            access_token=access_token,
+            refresh_token=refresh_token,
+            issued_at=int(time.time()),
+            scope=scope,
+            revoked=False,
+        )
+        return token
+
+
+class OAuth2CodeAuthorizationRequestForm:
+    def __init__(
+        self,
+        response_type: str = Query(None, regex="code"),
+        client_id: Optional[str] = Query(None),
+        redirect_uri: Optional[str] = Query(None),
+        scope: str = Query(""),
+        state: Optional[str] = Query(None),
+    ):
+        self.response_type = response_type
+        self.client_id = client_id
+        self.redirect_uri = redirect_uri
+        self.scopes = scope.split()
+        self.state = state
+
+
+class OAuth2CodeTokenRequestForm:
+    def __init__(
+        self,
+        code: str = Form(None),
+        grant_type: str = Form(None, regex="code"),
+        redirect_uri: Optional[str] = Form(None),
+        client_id: Optional[str] = Form(None),
+        client_secret: Optional[str] = Form(None),
+    ):
+        self.code = code
+        self.grant_type = grant_type
+        self.redirect_uri = redirect_uri
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
+# TODO: fix this properly
+settings = Settings(INSECURE_TRANSPORT=True)
+
+storage = Storage()
+authorization_server = AuthorizationServer(storage)

--- a/app/helpers/auth.py
+++ b/app/helpers/auth.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from dataclasses import asdict, dataclass
@@ -10,10 +11,12 @@ from aioauth.models import Client, Token
 from aioauth.requests import BaseRequest
 from aioauth.requests import Post as _Post
 from aioauth.requests import Query as _Query
+from aioauth.responses import Response as OAuth2Response
 from aioauth.server import AuthorizationServer
 from aioauth.storage import BaseStorage
 from aioauth.types import GrantType, RequestMethod, ResponseType, TokenType
 from starlette.requests import Request
+from starlette.responses import Response
 
 from app.config import get_settings
 from app.helpers.cache_utils import cache
@@ -58,6 +61,15 @@ async def get_oauth_settings() -> OAuth2Settings:
     )
 
     return oauth2_settings
+
+
+async def to_fastapi_response(oauth2_response: OAuth2Response) -> Response:
+    response_content = oauth2_response.content
+    headers = dict(oauth2_response.headers)
+    status_code = oauth2_response.status_code
+    content = json.dumps(response_content)
+
+    return Response(content=content, headers=headers, status_code=status_code)
 
 
 async def to_oauth2_request(request: Request, current_user: Optional[User] = None) -> OAuth2Request:

--- a/app/helpers/auth.py
+++ b/app/helpers/auth.py
@@ -40,7 +40,7 @@ class OAuth2Query(_Query):
 
 @dataclass
 class OAuth2Post(_Post):
-    consent: Optional[int] = 0
+    consent: Optional[str] = "0"
     channel: Optional[str] = None
 
 

--- a/app/helpers/auth.py
+++ b/app/helpers/auth.py
@@ -1,45 +1,147 @@
+import logging
 import time
+from dataclasses import asdict, dataclass
 from typing import Optional
 
-from aioauth.config import Settings
-from aioauth.models import AuthorizationCode, Client, Token
-from aioauth.requests import Request
+from aioauth.collections import HTTPHeaderDict
+from aioauth.config import Settings as OAuth2Settings
+from aioauth.models import AuthorizationCode as OAuth2Code
+from aioauth.models import Client, Token
+from aioauth.requests import Post as _Post
+from aioauth.requests import Query as _Query
+from aioauth.requests import Request as _Request
 from aioauth.server import AuthorizationServer
 from aioauth.storage import BaseStorage
-from aioauth.types import GrantType, ResponseType, TokenType
+from aioauth.types import GrantType, RequestMethod, ResponseType, TokenType
 from fastapi import Form, Query
+from starlette.requests import Request
 
 from app.config import get_settings
 from app.helpers.jwt import generate_jwt_token
-from app.models.app import App
+from app.models.app import App, AppInstalled
+from app.models.auth import AuthorizationCode
+from app.models.channel import Channel
 from app.models.user import User
+from app.schemas.apps import AppInstalledCreateSchema
+from app.schemas.auth import AuthorizationCodeCreateSchema
 from app.services.apps import get_app_by_client_id
-from app.services.crud import get_item
+from app.services.crud import create_item, delete_item, get_item, get_item_by_id, get_items
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OAuth2Query(_Query):
+    channel: Optional[str] = None
+
+
+@dataclass
+class OAuth2Post(_Post):
+    consent: Optional[int] = 0
+    channel: Optional[str] = None
+
+
+@dataclass
+class OAuth2Request(_Request):
+    query: OAuth2Query = OAuth2Query()
+    post: OAuth2Post = OAuth2Post()
+
+
+async def get_oauth_settings() -> OAuth2Settings:
+    settings = get_settings()
+    oauth2_settings = OAuth2Settings(
+        INSECURE_TRANSPORT=False if settings.environment == "production" else True,
+        TOKEN_EXPIRES_IN=settings.jwt_access_token_expire_minutes * 60,
+        REFRESH_TOKEN_EXPIRES_IN=settings.jwt_refresh_token_expire_minutes * 60,
+    )
+
+    return oauth2_settings
+
+
+async def to_oauth2_request(request: Request, current_user: Optional[User]) -> OAuth2Request:
+    oauth2_settings = await get_oauth_settings()
+    form = await request.form()
+    post = dict(form)
+    query_params = dict(request.query_params)
+    method = request.method
+    headers = HTTPHeaderDict(**request.headers)
+    url = str(request.url)
+
+    return OAuth2Request(
+        settings=oauth2_settings,
+        method=RequestMethod[method],
+        headers=headers,
+        post=OAuth2Post(**post),
+        query=OAuth2Query(**query_params),
+        url=url,
+        user=current_user,
+    )
 
 
 class Storage(BaseStorage):
-    """
-    Storage methods must be implemented here.
-    """
-
-    async def get_token(
+    async def create_authorization_code(
         self,
-        request: Request,
+        request: OAuth2Request,
         client_id: str,
-        token_type: Optional[str] = TokenType.REFRESH,
-        access_token: Optional[str] = None,
-        refresh_token: Optional[str] = None,
-    ) -> Optional[Token]:
-        pass
+        scope: str,
+        response_type: str,
+        redirect_uri: str,
+        code_challenge_method: Optional[str],
+        code_challenge: Optional[str],
+        code: str,
+    ) -> OAuth2Code:
+        app: App = await get_app_by_client_id(client_id=client_id)
+        if not app:
+            raise Exception("App not found")
 
-    async def authenticate(self, request: Request) -> bool:
-        pass
+        oauth2_settings = await get_oauth_settings()
+        authorization_code = OAuth2Code(
+            code=code,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            response_type=response_type,
+            scope=scope,
+            auth_time=int(time.time()),
+            code_challenge_method=code_challenge_method,
+            code_challenge=code_challenge,
+            expires_in=oauth2_settings.AUTHORIZATION_CODE_EXPIRES_IN,
+        )
 
-    async def revoke_token(self, request: Request, refresh_token: str) -> None:
-        pass
+        auth_code_schema = AuthorizationCodeCreateSchema(**asdict(authorization_code), app=str(app.pk))
+        await create_item(
+            item=auth_code_schema, result_obj=AuthorizationCode, user_field="user", current_user=request.user
+        )
+
+        return authorization_code
+
+    async def get_authorization_code(self, request: OAuth2Request, client_id: str, code: str) -> Optional[OAuth2Code]:
+        app: App = await get_app_by_client_id(client_id=client_id)
+        if not app:
+            return None
+
+        auth_code_item = await get_item(
+            filters={"code": code, "app": app.pk, "user": request.user},
+            result_obj=AuthorizationCode,
+        )
+
+        if not auth_code_item:
+            return None
+
+        auth_code = OAuth2Code(
+            code=code,
+            client_id=auth_code_item.client_id,
+            redirect_uri=auth_code_item.redirect_uri,
+            response_type=auth_code_item.response_type,
+            auth_time=auth_code_item.auth_time,
+            expires_in=auth_code_item.expires_in,
+            user=request.user,
+            scope=auth_code_item.scope,
+        )
+
+        return auth_code
 
     async def get_client(
-        self, request: Request, client_id: str, client_secret: Optional[str] = None
+        self, request: OAuth2Request, client_id: str, client_secret: Optional[str] = None
     ) -> Optional[Client]:
         app: App = await get_app_by_client_id(client_id=client_id)
         if not app:
@@ -54,34 +156,31 @@ class Storage(BaseStorage):
             user=app.creator,
         )
 
-    async def get_authorization_code(self, request: Request, client_id: str, code: str) -> Optional[AuthorizationCode]:
-        # TODO: fix this
-        default_user = await get_item(filters={}, result_obj=User)
+    async def delete_authorization_code(self, request: OAuth2Request, client_id: str, code: str) -> None:
         app: App = await get_app_by_client_id(client_id=client_id)
-        if not app:
-            return None
+        code_item = await get_item(filters={"code": code, "app": app.pk}, result_obj=AuthorizationCode)
+        if not code_item:
+            raise Exception(f"Code not found: {code}")
+        await delete_item(item=code_item)
 
-        auth_code = AuthorizationCode(
-            code=code,
-            client_id=client_id,
-            redirect_uri=request.query.redirect_uri,
-            response_type=ResponseType.TYPE_CODE,
-            auth_time=int(time.time()) - 5,
-            expires_in=300,
-            user=default_user,
-            scope=request.query.scope,
-        )
-        return auth_code
+    async def get_token(
+        self,
+        request: OAuth2Request,
+        client_id: str,
+        token_type: Optional[str] = TokenType.REFRESH,
+        access_token: Optional[str] = None,
+        refresh_token: Optional[str] = None,
+    ) -> Optional[Token]:
+        pass
 
-    async def delete_authorization_code(self, request: Request, client_id: str, code: str) -> None:
-        # TODO: delete codes...
-        return
+    async def revoke_token(self, request: OAuth2Request, refresh_token: str) -> None:
+        raise NotImplementedError()
 
-    async def create_token(self, request: Request, client_id: str, scope: str, *args) -> Token:
+    async def create_token(self, request: OAuth2Request, client_id: str, scope: str, *args) -> Token:
         app_settings = get_settings()
         app: App = await get_app_by_client_id(client_id=client_id)
         access_token = generate_jwt_token({"sub": str(app.pk), "client_id": client_id})
-        refresh_token = generate_jwt_token({"sub": str(app.pk)}, token_type="refresh")
+        refresh_token = generate_jwt_token({"sub": str(app.pk), "client_id": client_id}, token_type="refresh")
 
         # TODO: add caching
         # await cache.client.sadd(f"refresh_tokens:{str(app.pk)}", refresh_token)
@@ -91,6 +190,25 @@ class Storage(BaseStorage):
         #     user_field="app",
         #     current_user=app,
         # )
+
+        channel_id = request.post.channel
+        if not channel_id:
+            raise Exception("missing channel_id")
+
+        channel = await get_item_by_id(id_=channel_id, result_obj=Channel)
+
+        prev_installed_apps = await get_items(filters={"app": app.pk, "channel": channel.pk}, result_obj=AppInstalled)
+
+        if not prev_installed_apps:
+            # TODO: at this stage, the app has been verified and will be installed into the channel/server
+            install_model = AppInstalledCreateSchema(app=str(app.pk), channel=str(channel.pk))
+            new_install = await create_item(item=install_model, current_user=request.user, result_obj=AppInstalled)
+
+            logger.debug("New app installed: %s", new_install)
+
+            # # TODO: create app joined channel message
+            # message = AppMessageCreateSchema(channel=channel_id, app=str(app.pk))
+            # await create_app_message(message_model=message)
 
         token = Token(
             client_id=client_id,
@@ -137,8 +255,5 @@ class OAuth2CodeTokenRequestForm:
         self.client_secret = client_secret
 
 
-# TODO: fix this properly
-settings = Settings(INSECURE_TRANSPORT=True)
-
 storage = Storage()
-authorization_server = AuthorizationServer(storage)
+authorization_server = AuthorizationServer(storage=storage)

--- a/app/helpers/auth.py
+++ b/app/helpers/auth.py
@@ -215,6 +215,7 @@ class Storage(BaseStorage):
         if not r_token:
             raise Exception("refresh token not found")
         await delete_item(r_token)
+        await cache.client.srem(f"refresh_tokens:{str(r_token.app.pk)}", refresh_token)
 
     async def create_token(self, request: OAuth2Request, client_id: str, scope: str, *args) -> Token:
         app_settings = get_settings()

--- a/app/helpers/permissions.py
+++ b/app/helpers/permissions.py
@@ -308,7 +308,7 @@ async def fetch_user_permissions(
     return sorted(list(user_permissions))
 
 
-async def check_resource_permission(user: User, action: str, resource: Any) -> None:
+async def validate_resource_permission(user: User, action: str, resource: Any) -> None:
     user_id = str(user.pk)
 
     channel_id = None

--- a/app/main.py
+++ b/app/main.py
@@ -31,6 +31,7 @@ from app.routers import (
     integrations,
     media,
     messages,
+    oauth,
     sections,
     servers,
     stars,
@@ -88,6 +89,7 @@ def get_application(testing=False):
 
     app_.include_router(base.router)
     app_.include_router(auth.router, prefix="/auth", tags=["auth"])
+    app_.include_router(oauth.router, prefix="/oauth", tags=["oauth"])
     app_.include_router(users.router, prefix="/users", tags=["users"])
     app_.include_router(servers.router, prefix="/servers", tags=["servers"])
     app_.include_router(channels.router, prefix="/channels", tags=["channels"])

--- a/app/middlewares.py
+++ b/app/middlewares.py
@@ -64,15 +64,11 @@ async def add_canonical_log_line(request: Request, call_next):
         "http_status": response.status_code,
     }
 
-    try:
-        log_line_data["user_id"] = request.state.user_id
-    except AttributeError:
-        pass
-
-    try:
-        log_line_data["auth_type"] = request.state.auth_type
-    except AttributeError:
-        pass
+    for attr in ["user_id", "auth_type", "auth_source", "actor_type", "app_id"]:
+        try:
+            log_line_data[attr] = getattr(request.state, attr)
+        except AttributeError:
+            pass
 
     sorted_dict = dict(sorted(log_line_data.items(), key=lambda x: x[0].lower()))
 

--- a/app/models/app.py
+++ b/app/models/app.py
@@ -12,8 +12,7 @@ class App(APIDocument):
     client_id = fields.StrField()
     client_secret = fields.StrField()
     redirect_uris = fields.ListField(fields.StrField(), default=[])
-
-    permissions = fields.ListField(fields.StrField)
+    scopes = fields.ListField(fields.StrField, default=[])
 
     class Meta:
         collection_name = "apps"
@@ -24,6 +23,7 @@ class AppInstalled(APIDocument):
     app = fields.ReferenceField("App")
     user = fields.ReferenceField("User")
     channel = fields.ReferenceField("Channel")
+    scopes = fields.ListField(fields.StrField(), default=[])
 
     class Meta:
         collection_name = "apps_installed"

--- a/app/models/app.py
+++ b/app/models/app.py
@@ -11,6 +11,7 @@ class App(APIDocument):
     description = fields.StrField(required=False)
     client_id = fields.StrField()
     client_secret = fields.StrField()
+    redirect_uris = fields.ListField(fields.StrField(), default=[])
 
     permissions = fields.ListField(fields.StrField)
 

--- a/app/models/app.py
+++ b/app/models/app.py
@@ -17,3 +17,13 @@ class App(APIDocument):
 
     class Meta:
         collection_name = "apps"
+
+
+@instance.register
+class AppInstalled(APIDocument):
+    app = fields.ReferenceField("App")
+    user = fields.ReferenceField("User")
+    channel = fields.ReferenceField("Channel")
+
+    class Meta:
+        collection_name = "apps_installed"

--- a/app/models/app.py
+++ b/app/models/app.py
@@ -14,6 +14,9 @@ class App(APIDocument):
     redirect_uris = fields.ListField(fields.StrField(), default=[])
     scopes = fields.ListField(fields.StrField, default=[])
 
+    online_channels = fields.ListField(fields.StrField(), required=False, default=[])
+    status = fields.StrField(default="offline")
+
     class Meta:
         collection_name = "apps"
 

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -9,6 +9,7 @@ class RefreshToken(APIDocument):
     user = fields.ReferenceField("User", default=None, required=False)
     app = fields.ReferenceField("App", default=None, required=False)
     refresh_token = fields.StrField()
+    scopes = fields.ListField(fields.StrField(), default=[])
 
     used = fields.BoolField(default=False)
 

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -30,6 +30,7 @@ class AuthorizationCode(APIDocument):
     expires_in = fields.IntField()
     auth_time = fields.IntField()
     nonce = fields.StrField(required=False, default=None)
+    channel = fields.ReferenceField("Channel", required=False, default=None)
 
     class Meta:
         collection_name = "auth_codes"

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -6,7 +6,8 @@ from app.models.base import APIDocument
 
 @instance.register
 class RefreshToken(APIDocument):
-    user = fields.ReferenceField("User")
+    user = fields.ReferenceField("User", default=None, required=False)
+    app = fields.ReferenceField("App", default=None, required=False)
     refresh_token = fields.StrField()
 
     used = fields.BoolField(default=False)
@@ -14,3 +15,20 @@ class RefreshToken(APIDocument):
     class Meta:
         collection_name = "refresh_tokens"
         indexes = ["user"]
+
+
+@instance.register
+class AuthorizationCode(APIDocument):
+    user = fields.ReferenceField("User")
+    app = fields.ReferenceField("App")
+    client_id = fields.StrField()
+    code = fields.StrField()
+    redirect_uri = fields.StrField()
+    response_type = fields.StrField()
+    scope = fields.StrField()
+    expires_in = fields.IntField()
+    auth_time = fields.IntField()
+    nonce = fields.StrField(required=False, default=None)
+
+    class Meta:
+        collection_name = "auth_codes"

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -54,3 +54,9 @@ class AppMessage(Message):
 class WebhookMessage(AppMessage):
     webhook = fields.ReferenceField("Webhook", required=True)
     type = fields.IntField(default=2)
+
+
+@instance.register
+class AppInstallMessage(AppMessage):
+    installer = fields.ReferenceField("User", required=True)
+    type = fields.IntField(default=6)

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -55,7 +55,7 @@ async def post_create_channel(
     "/{channel_id}/messages",
     response_description="Get latest messages",
     response_model=List[EitherMessage],
-    dependencies=[Depends(PermissionsChecker(needs_user=False, permissions=["messages.list"]))],
+    dependencies=[Depends(PermissionsChecker(needs_bearer=False, permissions=["messages.list"]))],
 )
 async def get_list_messages(channel_id, common_params: dict = Depends(common_parameters)):
     return await get_messages(channel_id=channel_id, **common_params)
@@ -65,7 +65,7 @@ async def get_list_messages(channel_id, common_params: dict = Depends(common_par
     "/{channel_id}",
     response_description="Get channel info",
     response_model=EitherChannel,
-    dependencies=[Depends(PermissionsChecker(needs_user=False, permissions=["channels.view"]))],
+    dependencies=[Depends(PermissionsChecker(needs_bearer=False, permissions=["channels.view"]))],
 )
 async def get_fetch_channel(channel_id):
     return await get_channel(channel_id=channel_id)
@@ -75,7 +75,7 @@ async def get_fetch_channel(channel_id):
     "/{channel_id}/messages/{message_id}",
     response_description="Get message",
     response_model=EitherMessage,
-    dependencies=[Depends(PermissionsChecker(needs_user=False, permissions=["messages.list"]))],
+    dependencies=[Depends(PermissionsChecker(needs_bearer=False, permissions=["messages.list"]))],
 )
 async def get_specific_message(channel_id, message_id):
     return await get_message(channel_id=channel_id, message_id=message_id)
@@ -85,7 +85,7 @@ async def get_specific_message(channel_id, message_id):
     "/{channel_id}",
     response_description="Delete channel",
     response_model=EitherChannel,
-    dependencies=[Depends(PermissionsChecker(needs_user=False, permissions=["channels.delete"]))],
+    dependencies=[Depends(PermissionsChecker(needs_bearer=False, permissions=["channels.delete"]))],
 )
 async def delete_remove_channel(channel_id, current_user: User = Depends(get_current_user)):
     return await delete_channel(channel_id=channel_id, current_user=current_user)
@@ -183,7 +183,7 @@ async def post_join_server(channel_id: str, current_user: User = Depends(get_cur
     "/{channel_id}/members",
     response_description="List channel members",
     response_model=List[MemberUserSchema],
-    dependencies=[Depends(PermissionsChecker(needs_user=False, permissions=["channels.members.list"]))],
+    dependencies=[Depends(PermissionsChecker(needs_bearer=False, permissions=["channels.members.list"]))],
 )
 async def get_fetch_channel_members(channel_id: str):
     return await get_channel_members(channel_id=channel_id)

--- a/app/routers/messages.py
+++ b/app/routers/messages.py
@@ -2,11 +2,13 @@ import http
 
 from fastapi import APIRouter, Body, Depends
 
-from app.dependencies import PermissionsChecker, get_current_user
+from app.dependencies import PermissionsChecker, get_current_app, get_current_user
+from app.models.app import App
 from app.models.user import User
-from app.schemas.messages import MessageCreateSchema, MessageSchema, MessageUpdateSchema
+from app.schemas.messages import AppMessageCreateSchema, MessageCreateSchema, MessageSchema, MessageUpdateSchema
 from app.services.messages import (
     add_reaction_to_message,
+    create_app_message,
     create_message,
     create_reply_message,
     delete_message,
@@ -27,8 +29,14 @@ router = APIRouter()
 async def post_create_message(
     message: MessageCreateSchema = Body(...),
     current_user: User = Depends(get_current_user),
+    current_app: App = Depends(get_current_app),
 ):
-    return await create_message(message_model=message, current_user=current_user)
+    if not current_user and current_app:
+        # TODO: in the future we might get an app request impersonating a user and need to improve this logic
+        app_message = AppMessageCreateSchema(**message.dict(exclude_none=True, exclude_defaults=True))
+        return await create_app_message(message_model=app_message, current_app=current_app)
+    else:
+        return await create_message(message_model=message, current_user=current_user)
 
 
 @router.patch(

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -26,7 +26,7 @@ async def get_app_authorization_page():
 @router.post("/authorize")
 async def post_app_authorization_page(request: Request, current_user: User = Depends(get_current_user)):
     oauth2_request = await to_oauth2_request(request, current_user=current_user)
-    consent = bool(int(oauth2_request.post.consent))
+    consent = bool(int(oauth2_request.post.consent)) if oauth2_request.post.consent else False
     if not consent:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Consent not granted")
 

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -1,12 +1,11 @@
 import logging
 
-from aioauth_fastapi.utils import to_fastapi_response
 from fastapi import APIRouter, Depends, HTTPException
 from starlette import status
 from starlette.requests import Request
 
 from app.dependencies import get_current_client, get_current_user
-from app.helpers.auth import authorization_server, to_oauth2_request
+from app.helpers.auth import authorization_server, to_fastapi_response, to_oauth2_request
 from app.helpers.permissions import check_resource_permission
 from app.models.channel import Channel
 from app.models.user import User

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -7,7 +7,7 @@ from starlette import status
 from starlette.requests import Request
 from starlette.responses import RedirectResponse
 
-from app.dependencies import get_current_user
+from app.dependencies import get_current_client, get_current_user
 from app.helpers.auth import authorization_server, to_oauth2_request
 from app.helpers.permissions import check_resource_permission
 from app.models.channel import Channel
@@ -46,15 +46,11 @@ async def post_app_authorization_page(request: Request, current_user: User = Dep
     return await to_fastapi_response(oauth2_response)
 
 
-@router.post("/token")
-async def create_access_token(request: Request, current_user: User = Depends(get_current_user)):
-    oauth2_request = await to_oauth2_request(request, current_user=current_user)
-
+@router.post("/token", dependencies=[Depends(get_current_client)])
+async def create_access_token(request: Request):
+    oauth2_request = await to_oauth2_request(request)
     if not oauth2_request.post.channel:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing channel")
-
-    channel = await get_item_by_id(id_=oauth2_request.post.channel, result_obj=Channel)
-    await check_resource_permission(user=current_user, resource=channel, action="apps.manage")
 
     oauth2_response = await authorization_server.create_token_response(oauth2_request)
     return await to_fastapi_response(oauth2_response)

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -9,7 +9,7 @@ from starlette.responses import RedirectResponse
 from app.config import get_settings
 from app.dependencies import get_current_client, get_current_user
 from app.helpers.auth import authorization_server, to_fastapi_response, to_oauth2_request
-from app.helpers.permissions import check_resource_permission
+from app.helpers.permissions import validate_resource_permission
 from app.models.channel import Channel
 from app.models.user import User
 from app.services.crud import get_item_by_id
@@ -37,7 +37,7 @@ async def post_app_authorization_page(request: Request, current_user: User = Dep
     if not oauth2_request.query.channel:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing channel")
     channel = await get_item_by_id(id_=oauth2_request.query.channel, result_obj=Channel)
-    await check_resource_permission(user=current_user, resource=channel, action="apps.manage")
+    await validate_resource_permission(user=current_user, resource=channel, action="apps.manage")
 
     oauth2_response = await authorization_server.create_authorization_response(oauth2_request)
     if oauth2_response.status_code == status.HTTP_302_FOUND:

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -9,7 +9,10 @@ from starlette.responses import RedirectResponse
 
 from app.dependencies import get_current_user
 from app.helpers.auth import authorization_server, to_oauth2_request
+from app.helpers.permissions import check_resource_permission
+from app.models.channel import Channel
 from app.models.user import User
+from app.services.crud import get_item_by_id
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +23,7 @@ router = APIRouter()
 async def get_app_authorization_page(request: Request):
     query = dict(request.query_params)
     # TODO: better handle this...
-    location = build_uri("http://localhost:8080/oauth/authorize", query, None)
+    location = build_uri(url="http://localhost:8080/oauth/authorize", query_params=query)
 
     # TODO: still need to validate client id and so on...
 
@@ -30,12 +33,14 @@ async def get_app_authorization_page(request: Request):
 @router.post("/authorize")
 async def post_app_authorization_page(request: Request, current_user: User = Depends(get_current_user)):
     oauth2_request = await to_oauth2_request(request, current_user=current_user)
-    if not oauth2_request.query.channel:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing channel")
-
     consent = bool(int(oauth2_request.post.consent))
     if not consent:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Consent not granted")
+
+    if not oauth2_request.query.channel:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing channel")
+    channel = await get_item_by_id(id_=oauth2_request.query.channel, result_obj=Channel)
+    await check_resource_permission(user=current_user, resource=channel, action="apps.manage")
 
     oauth2_response = await authorization_server.create_authorization_response(oauth2_request)
     return await to_fastapi_response(oauth2_response)
@@ -44,5 +49,12 @@ async def post_app_authorization_page(request: Request, current_user: User = Dep
 @router.post("/token")
 async def create_access_token(request: Request, current_user: User = Depends(get_current_user)):
     oauth2_request = await to_oauth2_request(request, current_user=current_user)
+
+    if not oauth2_request.post.channel:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing channel")
+
+    channel = await get_item_by_id(id_=oauth2_request.post.channel, result_obj=Channel)
+    await check_resource_permission(user=current_user, resource=channel, action="apps.manage")
+
     oauth2_response = await authorization_server.create_token_response(oauth2_request)
     return await to_fastapi_response(oauth2_response)

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -1,9 +1,12 @@
 import logging
 
+from aioauth.utils import build_uri
 from fastapi import APIRouter, Depends, HTTPException
 from starlette import status
 from starlette.requests import Request
+from starlette.responses import RedirectResponse
 
+from app.config import get_settings
 from app.dependencies import get_current_client, get_current_user
 from app.helpers.auth import authorization_server, to_fastapi_response, to_oauth2_request
 from app.helpers.permissions import check_resource_permission
@@ -17,9 +20,11 @@ router = APIRouter()
 
 
 @router.get("/authorize")
-async def get_app_authorization_page():
-    # TODO: might want to allow this and instead return a RedirectResponse() to the frontend
-    raise HTTPException(status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
+async def get_app_authorization_page(request: Request):
+    settings = get_settings()
+    query = dict(request.query_params)
+    location = build_uri(url=f"{settings.frontend_url}/oauth/authorize", query_params=query)
+    return RedirectResponse(location)
 
 
 @router.post("/authorize")

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -1,0 +1,73 @@
+import logging
+
+from aioauth.collections import HTTPHeaderDict
+from aioauth.config import Settings
+from aioauth.requests import Post
+from aioauth.requests import Query as OAuth2Query
+from aioauth.requests import Request as OAuth2Request
+from aioauth.types import RequestMethod
+from aioauth_fastapi.utils import to_fastapi_response
+from fastapi import APIRouter
+from starlette.requests import Request
+from starlette.responses import RedirectResponse
+
+from app.helpers.auth import authorization_server
+from app.models.user import User
+from app.services.crud import get_item
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/authorize")
+@router.post("/authorize")
+async def get_app_authorization_page(request: Request):
+    # TODO: only diff between aioauth router and ours is the user. maybe add user to request and use theirs?
+
+    # TODO: sort out redirection between GET and POST
+    # if request.method == "GET":
+    #     url = "http://localhost:8080/oauth/authorize"
+    #     return RedirectResponse(url)
+
+    form = await request.form()
+    post = dict(form)
+    query_params = dict(request.query_params)
+    headers = HTTPHeaderDict(**request.headers)
+    url = str(request.url)
+    settings = Settings(INSECURE_TRANSPORT=True)
+    default_user = await get_item(filters={}, result_obj=User)
+    oauth2_request = OAuth2Request(
+        settings=settings,
+        method=RequestMethod[request.method],
+        headers=headers,
+        post=Post(**post),
+        query=OAuth2Query(**query_params),
+        url=url,
+        user=default_user,
+    )
+
+    oauth2_response = await authorization_server.create_authorization_response(oauth2_request)
+    return await to_fastapi_response(oauth2_response)
+
+
+@router.post("/token")
+async def create_access_token(request: Request):
+    form = await request.form()
+    post = dict(form)
+    query_params = dict(request.query_params)
+    headers = HTTPHeaderDict(**request.headers)
+    url = str(request.url)
+    settings = Settings(INSECURE_TRANSPORT=True)
+    default_user = await get_item(filters={}, result_obj=User)
+    oauth2_request = OAuth2Request(
+        settings=settings,
+        method=RequestMethod[request.method],
+        headers=headers,
+        post=Post(**post),
+        query=OAuth2Query(**query_params),
+        url=url,
+        user=default_user,
+    )
+    oauth2_response = await authorization_server.create_token_response(oauth2_request)
+    return await to_fastapi_response(oauth2_response)

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -36,14 +36,15 @@ async def post_app_authorization_page(request: Request, current_user: User = Dep
     await check_resource_permission(user=current_user, resource=channel, action="apps.manage")
 
     oauth2_response = await authorization_server.create_authorization_response(oauth2_request)
+    if oauth2_response.status_code == status.HTTP_302_FOUND:
+        location = oauth2_response.headers.get("location")
+        return {"location": location}
+
     return await to_fastapi_response(oauth2_response)
 
 
 @router.post("/token", dependencies=[Depends(get_current_client)])
 async def create_access_token(request: Request):
     oauth2_request = await to_oauth2_request(request)
-    if not oauth2_request.post.channel:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing channel")
-
     oauth2_response = await authorization_server.create_token_response(oauth2_request)
     return await to_fastapi_response(oauth2_response)

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -1,11 +1,9 @@
 import logging
 
-from aioauth.utils import build_uri
 from aioauth_fastapi.utils import to_fastapi_response
 from fastapi import APIRouter, Depends, HTTPException
 from starlette import status
 from starlette.requests import Request
-from starlette.responses import RedirectResponse
 
 from app.dependencies import get_current_client, get_current_user
 from app.helpers.auth import authorization_server, to_oauth2_request
@@ -20,14 +18,9 @@ router = APIRouter()
 
 
 @router.get("/authorize")
-async def get_app_authorization_page(request: Request):
-    query = dict(request.query_params)
-    # TODO: better handle this...
-    location = build_uri(url="http://localhost:8080/oauth/authorize", query_params=query)
-
-    # TODO: still need to validate client id and so on...
-
-    return RedirectResponse(location)
+async def get_app_authorization_page():
+    # TODO: might want to allow this and instead return a RedirectResponse() to the frontend
+    raise HTTPException(status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 @router.post("/authorize")

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -54,7 +54,7 @@ async def fetch_get_user_channels(current_user: User = Depends(get_current_user)
     "/info",
     response_description="Get users info",
     response_model=List[PublicUserSchema],
-    dependencies=[Depends(PermissionsChecker(needs_user=True))],
+    dependencies=[Depends(PermissionsChecker(needs_bearer=True))],
 )
 async def post_get_users_info(data=Body(...)):
     return await get_users_info(data)

--- a/app/routers/webhooks.py
+++ b/app/routers/webhooks.py
@@ -55,12 +55,11 @@ async def post_create_webhook_message_with_secret(
     app = await webhook.app.fetch()
 
     message.channel = webhook.channel
-    message.app = str(app.pk)
     message.webhook = webhook_id
 
     try:
         # TODO queue this
-        await create_app_message(message_model=message)
+        await create_app_message(message_model=message, current_app=app)
     except Exception as e:
         logger.exception(e)
         capture_exception(e)

--- a/app/routers/webhooks.py
+++ b/app/routers/webhooks.py
@@ -10,7 +10,7 @@ from app.helpers.websockets import pusher_client
 from app.models.webhook import Webhook
 from app.schemas.messages import WebhookMessageCreateSchema
 from app.services.crud import get_item_by_id
-from app.services.messages import create_webhook_message
+from app.services.messages import create_app_message
 from app.services.webhooks import handle_pusher_event
 
 logger = logging.getLogger(__name__)
@@ -60,7 +60,7 @@ async def post_create_webhook_message_with_secret(
 
     try:
         # TODO queue this
-        await create_webhook_message(message_model=message)
+        await create_app_message(message_model=message)
     except Exception as e:
         logger.exception(e)
         capture_exception(e)

--- a/app/routers/websockets.py
+++ b/app/routers/websockets.py
@@ -2,8 +2,9 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Form
 
-from app.dependencies import get_current_user
+from app.dependencies import get_current_app, get_current_user
 from app.helpers.websockets import pusher_client
+from app.models.app import App
 from app.models.user import User
 
 router = APIRouter()
@@ -15,12 +16,21 @@ async def post_websocket_authentication(
     channel_name: str = Form(...),
     socket_id: str = Form(...),
     current_user: User = Depends(get_current_user),
+    current_app: App = Depends(get_current_app),
 ):
     if not provider or provider != "pusher":
         raise NotImplementedError("can only use Pusher for auth.")
 
-    expected_start_channel_name = f"private-{str(current_user.id)}"
+    if current_user:
+        pusher_channel_id = str(current_user.pk)
+    elif current_app:
+        pusher_channel_id = str(current_app.pk)
+    else:
+        raise Exception("no current user or app")
+
+    expected_start_channel_name = f"private-{pusher_channel_id}"
     if not channel_name.startswith(expected_start_channel_name):
         raise Exception(f"problem establishing connection: unexpected channel name {channel_name}")
+
     auth = pusher_client.authenticate(channel=channel_name, socket_id=socket_id)
     return auth

--- a/app/schemas/apps.py
+++ b/app/schemas/apps.py
@@ -14,7 +14,7 @@ class AppCreateSchema(APIBaseCreateSchema):
     description: Optional[str] = ""
     client_id: str = ""
     client_secret: str = ""
-    permissions: List[str] = []
+    scopes: List[str] = []
     redirect_uris: List[str] = []
 
     class Config:
@@ -22,7 +22,7 @@ class AppCreateSchema(APIBaseCreateSchema):
             "example": {
                 "name": "Github",
                 "description": "Github integration for posting events",
-                "permissions": ["messages.create"],
+                "scopes": ["messages.create"],
             }
         }
 
@@ -45,11 +45,13 @@ class AppInstalledSchema(APIBaseSchema):
 class AppInstalledCreateSchema(APIBaseCreateSchema):
     app: str
     channel: Optional[str]
+    scopes: Optional[List[str]] = []
 
     class Config:
         schema_extra = {
             "example": {
                 "app": "12313123",
                 "channel": "123123123123",
+                "scopes": ["messages.list", "channels.list"],
             }
         }

--- a/app/schemas/apps.py
+++ b/app/schemas/apps.py
@@ -15,6 +15,7 @@ class AppCreateSchema(APIBaseCreateSchema):
     client_id: str = ""
     client_secret: str = ""
     permissions: List[str] = []
+    redirect_uris: List[str] = []
 
     class Config:
         schema_extra = {

--- a/app/schemas/apps.py
+++ b/app/schemas/apps.py
@@ -24,3 +24,31 @@ class AppCreateSchema(APIBaseCreateSchema):
                 "permissions": ["messages.create"],
             }
         }
+
+
+class AppInstalledSchema(APIBaseSchema):
+    app: PyObjectId
+    user: PyObjectId
+    channel: PyObjectId
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "app": "",
+                "user": "<user_id>",
+                "channel": "5e8f8f8f8f8f8f8f8f8f8f8f",
+            }
+        }
+
+
+class AppInstalledCreateSchema(APIBaseCreateSchema):
+    app: str
+    channel: Optional[str]
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "app": "12313123",
+                "channel": "123123123123",
+            }
+        }

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -67,6 +67,7 @@ class AuthorizationCodeCreateSchema(APIBaseCreateSchema):
     auth_time: int
     expires_in: int
     nonce: Optional[str] = ""
+    channel: str
 
     class Config:
         allow_population_by_field_name = True

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -45,12 +45,14 @@ class RefreshTokenCreateSchema(APIBaseCreateSchema):
     user: Optional[str]
     app: Optional[str]
     refresh_token: str
+    scopes: Optional[List[str]] = []
 
     class Config:
         allow_population_by_field_name = True
         schema_extra = {
             "example": {
                 "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6Ikpasdfa.....bDZW6RHWpkQpwqkDopjSoiNDc2sHglWQ2TjdkM_1234",
+                "scopes": ["messages.list", "messages.create"],
             }
         }
 

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -43,6 +43,7 @@ class AccessTokenSchema(BaseModel):
 
 class RefreshTokenCreateSchema(APIBaseCreateSchema):
     user: Optional[str]
+    app: Optional[str]
     refresh_token: str
 
     class Config:
@@ -52,3 +53,18 @@ class RefreshTokenCreateSchema(APIBaseCreateSchema):
                 "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6Ikpasdfa.....bDZW6RHWpkQpwqkDopjSoiNDc2sHglWQ2TjdkM_1234",
             }
         }
+
+
+class AuthorizationCodeCreateSchema(APIBaseCreateSchema):
+    app: str
+    code: str
+    client_id: str
+    redirect_uri: str
+    response_type: str
+    scope: str
+    auth_time: int
+    expires_in: int
+    nonce: Optional[str] = ""
+
+    class Config:
+        allow_population_by_field_name = True

--- a/app/schemas/messages.py
+++ b/app/schemas/messages.py
@@ -90,5 +90,15 @@ class WebhookMessageSchema(AppMessageSchema):
     type: Optional[int] = 2
 
 
+class AppInstallMessageCreateSchema(AppMessageCreateSchema):
+    installer: Optional[str]
+    type: int = 6
+
+
+class AppInstallMessageSchema(AppMessageSchema):
+    installer: PyObjectId = Field()
+    type: Optional[int] = 6
+
+
 class EitherMessage(BaseModel):
-    __root__: Union[WebhookMessageSchema, AppMessageSchema, MessageSchema]
+    __root__: Union[WebhookMessageSchema, AppInstallMessageSchema, AppMessageSchema, MessageSchema]

--- a/app/schemas/messages.py
+++ b/app/schemas/messages.py
@@ -13,6 +13,7 @@ class MessageReactionSchema(APIEmbeddedBaseSchema):
 
 
 class MessageSchema(APIBaseSchema):
+    app: Optional[PyObjectId]
     author: Optional[PyObjectId] = Field()
     server: Optional[PyObjectId] = Field()
     channel: PyObjectId = Field()

--- a/app/services/apps.py
+++ b/app/services/apps.py
@@ -8,7 +8,7 @@ from app.models.user import User
 from app.models.webhook import Webhook
 from app.schemas.apps import AppCreateSchema
 from app.schemas.webhooks import WebhookCreateSchema
-from app.services.crud import create_item, get_item_by_id, get_items
+from app.services.crud import create_item, get_item, get_item_by_id, get_items
 
 
 async def create_app(model: AppCreateSchema, current_user: User):
@@ -30,3 +30,7 @@ async def create_app_webhook(app_id: str, webhook_data: WebhookCreateSchema, cur
 
 async def get_apps():
     return await get_items(filters={}, result_obj=App)
+
+
+async def get_app_by_client_id(client_id):
+    return await get_item(filters={"client_id": client_id}, result_obj=App)

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -1,12 +1,14 @@
 import json
 import logging
+from typing import Optional, Union
 
 from app.helpers.queue_utils import queue_bg_task
 from app.helpers.ws_events import WebSocketServerEvent
+from app.models.app import App
 from app.models.user import User
 from app.schemas.ws_events import CreateMarkChannelReadEvent
 from app.services.channels import update_channels_read_state
-from app.services.crud import update_item
+from app.services.crud import get_item_by_id, update_item
 from app.services.users import get_user_by_id
 from app.services.websockets import broadcast_connection_ready, broadcast_user_servers_event
 
@@ -22,18 +24,35 @@ async def _get_user_from_event(event: dict) -> User:
     return user
 
 
+async def _get_actor_from_event(event: dict) -> Optional[Union[User, App]]:
+    channel_name = event["channel"]
+    actor_id = channel_name.split("-")[1]
+    user = await get_user_by_id(actor_id)
+    if user:
+        return user
+
+    app = await get_item_by_id(id_=actor_id, result_obj=App)
+    if app:
+        return app
+
+    return None
+
+
 async def handle_pusher_event(event: dict):
     event_name = event["name"]
     if event_name == "client_event":
         return await handle_pusher_client_event(event)
 
     channel_name = event["channel"]
-    user = await _get_user_from_event(event)
+    actor = await _get_actor_from_event(event)
+
+    if not actor:
+        raise Exception(f"Missing actor. [channel_name={channel_name}]")
 
     if event_name == "channel_occupied":
-        await process_channel_occupied_event(channel_name=channel_name, current_user=user)
+        await process_channel_occupied_event(channel_name=channel_name, actor=actor)
     elif event_name == "channel_vacated":
-        await process_channel_vacated_event(channel_name=channel_name, current_user=user)
+        await process_channel_vacated_event(channel_name=channel_name, actor=actor)
     else:
         raise NotImplementedError(f"not expected event: {event}")
 
@@ -60,29 +79,31 @@ async def handle_pusher_client_event(event: dict):
     logger.info("client event handled successfully. [client_event=%s, channel=%s]", client_event, channel_name)
 
 
-async def process_channel_occupied_event(channel_name: str, current_user: User):
+async def process_channel_occupied_event(channel_name: str, actor: Union[User, App]):
     update_data = {"$addToSet": {"online_channels": channel_name}, "$set": {"status": "online"}}
-    await User.collection.update_one(filter={"_id": current_user.pk}, update=update_data)
-    await queue_bg_task(
-        broadcast_user_servers_event,
-        str(current_user.id),
-        WebSocketServerEvent.USER_PRESENCE_UPDATE,
-        {"status": "online"},
-    )
-
-
-async def process_channel_vacated_event(channel_name: str, current_user: User):
-    update_data = {"$pull": {"online_channels": channel_name}}
-    await User.collection.update_one(filter={"_id": current_user.pk}, update=update_data)
-    await current_user.reload()
-    if len(current_user.online_channels) == 0:
-        await update_item(item=current_user, data={"status": "offline"})
+    await actor.__class__.collection.update_one(filter={"_id": actor.pk}, update=update_data)
+    if isinstance(actor, User):
         await queue_bg_task(
             broadcast_user_servers_event,
-            str(current_user.id),
+            str(actor.id),
             WebSocketServerEvent.USER_PRESENCE_UPDATE,
-            {"status": "offline"},
+            {"status": "online"},
         )
+
+
+async def process_channel_vacated_event(channel_name: str, actor: Union[User, App]):
+    update_data = {"$pull": {"online_channels": channel_name}}
+    await actor.__class__.collection.update_one(filter={"_id": actor.pk}, update=update_data)
+    await actor.reload()
+    if len(actor.online_channels) == 0:
+        await update_item(item=actor, data={"status": "offline"})
+        if isinstance(actor, User):
+            await queue_bg_task(
+                broadcast_user_servers_event,
+                str(actor.id),
+                WebSocketServerEvent.USER_PRESENCE_UPDATE,
+                {"status": "offline"},
+            )
 
 
 async def process_channel_mark_read_event(event_model: CreateMarkChannelReadEvent, current_user: User):

--- a/app/services/websockets.py
+++ b/app/services/websockets.py
@@ -25,7 +25,7 @@ async def _get_users_online_channels(users: List[User]):
 
 async def _get_apps_online_channels(apps: List[App]):
     channels = []
-    user: App
+    app: App
     for app in apps:
         channels.extend(app.online_channels)
     return list(set(channels))
@@ -58,6 +58,8 @@ async def get_channel_online_channels(channel: Channel, current_user: Optional[U
 
     online_channels = await _get_users_online_channels(users)
 
+    # TODO: This might slow down the websocket publishing... in the long run, it's best to dispatch user and app events
+    # in parallel
     installed_apps = await get_items(filters={"channel": channel.pk}, result_obj=AppInstalled, limit=None)
     if len(installed_apps) > 0:
         app_ids = {install.app.pk for install in installed_apps}

--- a/app/services/websockets.py
+++ b/app/services/websockets.py
@@ -60,7 +60,7 @@ async def get_channel_online_channels(channel: Channel, current_user: Optional[U
 
     installed_apps = await get_items(filters={"channel": channel.pk}, result_obj=AppInstalled, limit=None)
     if len(installed_apps) > 0:
-        app_ids = set([install.app.pk for install in installed_apps])
+        app_ids = {install.app.pk for install in installed_apps}
         apps = await get_items(filters={"_id": {"$in": list(app_ids)}}, result_obj=App, limit=None)
         app_channels = await _get_apps_online_channels(apps)
         online_channels.extend(app_channels)

--- a/app/services/websockets.py
+++ b/app/services/websockets.py
@@ -5,6 +5,7 @@ from sentry_sdk import capture_exception
 
 from app.helpers.websockets import pusher_client
 from app.helpers.ws_events import WebSocketServerEvent
+from app.models.app import App, AppInstalled
 from app.models.channel import Channel
 from app.models.message import Message
 from app.models.server import Server, ServerMember
@@ -19,6 +20,14 @@ async def _get_users_online_channels(users: List[User]):
     user: User
     for user in users:
         channels.extend(user.online_channels)
+    return list(set(channels))
+
+
+async def _get_apps_online_channels(apps: List[App]):
+    channels = []
+    user: App
+    for app in apps:
+        channels.extend(app.online_channels)
     return list(set(channels))
 
 
@@ -40,12 +49,23 @@ async def get_channel_online_channels(channel: Channel, current_user: Optional[U
             user_ids.add(member.pk)
     elif channel.kind == "server":
         members = await get_items(filters={"server": channel.server.pk}, result_obj=ServerMember, limit=None)
+        # TODO: further permission check to see if user can actually read message in server channel.
+        # As long as we're not using Servers, this is not needed.
         for member in members:
             user_ids.add(member.user.pk)
 
     users = await get_items(filters={"_id": {"$in": list(user_ids)}}, result_obj=User, limit=None)
 
-    return await _get_users_online_channels(users)
+    online_channels = await _get_users_online_channels(users)
+
+    installed_apps = await get_items(filters={"channel": channel.pk}, result_obj=AppInstalled, limit=None)
+    if len(installed_apps) > 0:
+        app_ids = set([install.app.pk for install in installed_apps])
+        apps = await get_items(filters={"_id": {"$in": list(app_ids)}}, result_obj=App, limit=None)
+        app_channels = await _get_apps_online_channels(apps)
+        online_channels.extend(app_channels)
+
+    return online_channels
 
 
 async def get_servers_online_channels(servers: List[Server], current_user: Optional[User]):
@@ -99,6 +119,7 @@ async def pusher_broadcast_messages(
 
     if not pusher_channels:
         logger.debug("no online pusher channels. [scope=%s, event=%s]", scope, event)
+        return
 
     event_name: str = event.value
     has_errors = False

--- a/app/tests/routers/test_channels.py
+++ b/app/tests/routers/test_channels.py
@@ -678,7 +678,7 @@ class TestChannelsRoutes:
         normal_message = json_response[1]
         assert normal_message.get("type") == 0
         assert normal_message.get("author") == str(current_user.pk)
-        assert "app" not in normal_message
+        assert normal_message.get("app") is None
         assert "webhook" not in normal_message
 
     @pytest.mark.asyncio

--- a/app/tests/routers/test_channels.py
+++ b/app/tests/routers/test_channels.py
@@ -22,7 +22,7 @@ from app.schemas.sections import SectionCreateSchema
 from app.schemas.servers import ServerCreateSchema
 from app.services.channels import create_server_channel, get_dm_channels
 from app.services.crud import create_item, get_item, get_item_by_id
-from app.services.messages import create_message, create_webhook_message
+from app.services.messages import create_app_message, create_message
 from app.services.servers import create_server, get_user_servers
 from app.services.users import get_user_by_id, get_user_by_wallet_address
 
@@ -662,7 +662,7 @@ class TestChannelsRoutes:
             content="webhook message!",
             channel=str(integration_app_webhook.channel.pk),
         )
-        await create_webhook_message(message_model=wh_message_model)
+        await create_app_message(message_model=wh_message_model)
 
         response = await authorized_client.get(f"/channels/{str(server_channel.pk)}/messages")
         assert response.status_code == 200

--- a/app/tests/routers/test_messages.py
+++ b/app/tests/routers/test_messages.py
@@ -1288,3 +1288,26 @@ class TestMessagesRoutes:
         after_id = "0"
         response = await authorized_client.get(f"channels/{str(server_channel.pk)}/messages?after={after_id}&limit=3")
         assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_create_message_as_app(
+        self,
+        app: FastAPI,
+        db: Database,
+        topic_channel: Channel,
+        integration_app: App,
+        get_app_authorized_client: Callable,
+    ):
+        data = {"content": "gm!", "channel": str(topic_channel.pk)}
+        app_client = await get_app_authorized_client(integration_app, channels=[topic_channel])
+        response = await app_client.post("/messages", json=data)
+        assert response.status_code == 201
+        json_response = response.json()
+        assert json_response != {}
+        assert "content" in json_response
+        assert json_response["content"] == data["content"]
+        assert json_response["channel"] == data["channel"] == str(topic_channel.pk)
+        assert json_response["author"] is None
+        assert json_response["app"] is not None
+        assert json_response["app"] == str(integration_app.pk)
+        assert json_response["type"] == 3

--- a/app/tests/routers/test_messages.py
+++ b/app/tests/routers/test_messages.py
@@ -18,7 +18,7 @@ from app.models.user import User
 from app.models.webhook import Webhook
 from app.schemas.messages import MessageCreateSchema, WebhookMessageCreateSchema
 from app.services.crud import create_item, get_item_by_id
-from app.services.messages import create_webhook_message, get_messages
+from app.services.messages import create_app_message, get_messages
 
 
 class TestMessagesRoutes:
@@ -1011,7 +1011,7 @@ class TestMessagesRoutes:
             content="webhook message!",
             channel=str(integration_app_webhook.channel.pk),
         )
-        wh_message = await create_webhook_message(message_model=wh_message_model)
+        wh_message = await create_app_message(message_model=wh_message_model)
 
         response = await authorized_client.get(f"/channels/{str(server_channel.id)}/messages/{str(wh_message.id)}")
         assert response.status_code == 200

--- a/app/tests/routers/test_oauth.py
+++ b/app/tests/routers/test_oauth.py
@@ -49,12 +49,12 @@ class TestOAuthRoutes:
         url = urlparse(location)
         assert f"{url.scheme}://{url.netloc}" == redirect_uri
 
-        params = parse_qs(url.query)
-        code = params.get("code")
+        url_params: dict = parse_qs(url.query)
+        code = url_params.get("code")
         assert code is not None
         assert code != ""
 
-        redirect_state = params.get("state")[0]
+        redirect_state = url_params.get("state", [])[0]
         assert redirect_state is not None
         assert redirect_state != ""
         assert redirect_state == state
@@ -237,12 +237,12 @@ class TestOAuthRoutes:
         url = urlparse(location)
         assert f"{url.scheme}://{url.netloc}" == redirect_uri
 
-        params = parse_qs(url.query)
-        code = params.get("code")
+        url_params: dict = parse_qs(url.query)
+        code = url_params.get("code")
         assert code is not None
         assert code != ""
 
-        redirect_state = params.get("state")[0]
+        redirect_state = url_params.get("state", [])[0]
         assert redirect_state is not None
         assert redirect_state != ""
         assert redirect_state == state
@@ -301,12 +301,12 @@ class TestOAuthRoutes:
         url = urlparse(location)
         assert f"{url.scheme}://{url.netloc}" == redirect_uri
 
-        params = parse_qs(url.query)
-        code = params.get("code")
+        url_params: dict = parse_qs(url.query)
+        code = url_params.get("code")
         assert code is not None
         assert code != ""
 
-        redirect_state = params.get("state")[0]
+        redirect_state = url_params.get("state", [])[0]
         assert redirect_state is not None
         assert redirect_state != ""
         assert redirect_state == state
@@ -422,8 +422,8 @@ class TestOAuthRoutes:
         url = urlparse(location)
         assert f"{url.scheme}://{url.netloc}" == redirect_uri
 
-        params = parse_qs(url.query)
-        code = params.get("code")
+        url_params: dict = parse_qs(url.query)
+        code = url_params.get("code")
         assert code is not None
         assert code != ""
 

--- a/app/tests/routers/test_oauth.py
+++ b/app/tests/routers/test_oauth.py
@@ -1,0 +1,140 @@
+import secrets
+from typing import Callable
+
+import pytest
+from fastapi import FastAPI
+from httpx import URL, AsyncClient
+from pymongo.database import Database
+
+from app.models.channel import Channel
+from app.models.user import User
+from app.schemas.apps import AppCreateSchema
+from app.services.apps import create_app
+
+
+class TestOAuthRoutes:
+    @pytest.mark.asyncio
+    async def test_oauth2_code_flow_ok(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+    ):
+        redirect_uri = "https://example.com"
+        state = secrets.token_urlsafe(32)
+
+        app_schema = AppCreateSchema(name="test", redirect_uris=[redirect_uri])
+        integration = await create_app(model=app_schema, current_user=current_user)
+        assert integration is not None
+
+        params = {
+            "client_id": integration.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": "",
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+            "state": state,
+        }
+
+        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
+        assert response.status_code == 307
+
+        form_data = {"consent": 1}
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
+        assert response.status_code == 200
+        url: URL = response.url
+        assert f"{url.scheme}://{url.netloc.decode('ascii')}" == redirect_uri
+
+        code = url.params.get("code")
+        assert code is not None
+        assert code != ""
+
+        redirect_state = url.params.get("state")
+        assert redirect_state is not None
+        assert redirect_state != ""
+        assert redirect_state == state
+
+        data = {
+            "code": code,
+            "client_id": integration.client_id,
+            "client_secret": integration.client_secret,
+            "grant_type": "authorization_code",
+            "redirect_uri": redirect_uri,
+            "channel": str(topic_channel.pk),
+        }
+
+        response = await user_auth_client.post("/oauth/token", data=data)
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+        assert "refresh_token" in response.json()
+        assert "expires_in" in response.json()
+        assert "token_type" in response.json()
+
+    @pytest.mark.asyncio
+    async def test_oauth2_code_flow_missing_channel(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        get_authorized_client: Callable,
+    ):
+        redirect_uri = "https://example.com"
+        app_schema = AppCreateSchema(name="test", redirect_uris=[redirect_uri])
+        integration = await create_app(model=app_schema, current_user=current_user)
+        assert integration is not None
+
+        params = {
+            "client_id": integration.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": "",
+            "response_type": "code",
+        }
+
+        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
+        assert response.status_code == 307
+
+        form_data = {"consent": 1}
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
+        assert response.status_code == 400
+        assert "Missing channel" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_oauth2_code_flow_no_consent(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+    ):
+        redirect_uri = "https://example.com"
+        state = secrets.token_urlsafe(32)
+
+        app_schema = AppCreateSchema(name="test", redirect_uris=[redirect_uri])
+        integration = await create_app(model=app_schema, current_user=current_user)
+        assert integration is not None
+
+        params = {
+            "client_id": integration.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": "",
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+            "state": state,
+        }
+
+        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
+        assert response.status_code == 307
+
+        form_data = {"consent": 0}
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
+        assert response.status_code == 400
+        assert "Consent not granted" in response.json()["detail"]

--- a/app/tests/routers/test_oauth.py
+++ b/app/tests/routers/test_oauth.py
@@ -1,3 +1,4 @@
+import asyncio
 import secrets
 from typing import Callable
 from urllib.parse import parse_qs, urlparse
@@ -7,6 +8,8 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from pymongo.database import Database
 
+from app.config import get_settings
+from app.helpers.auth import get_oauth_settings
 from app.models.channel import Channel
 from app.models.user import User
 from app.schemas.apps import AppCreateSchema
@@ -508,3 +511,144 @@ class TestOAuthRoutes:
         json_resp = response.json()
         assert "access_token" in json_resp
         assert "refresh_token" in json_resp
+
+    @pytest.mark.asyncio
+    async def test_oauth2_access_token_expiry(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+        monkeypatch,
+        get_app_authorized_client: Callable,
+    ):
+        get_settings.cache_clear()
+        monkeypatch.setenv("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", "0")
+        current_settings = await get_oauth_settings()
+        assert current_settings.TOKEN_EXPIRES_IN < 1
+
+        redirect_uri = "https://example.com"
+        state = secrets.token_urlsafe(32)
+
+        app_schema = AppCreateSchema(name="test", redirect_uris=[redirect_uri])
+        integration = await create_app(model=app_schema, current_user=current_user)
+        assert integration is not None
+
+        params = {
+            "client_id": integration.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": "",
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+            "state": state,
+        }
+
+        form_data = {"consent": 1}
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
+        assert response.status_code == 200
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
+
+        url_params: dict = parse_qs(url.query)
+        code = url_params.get("code")
+        assert code is not None
+        assert code != ""
+
+        data = {
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": redirect_uri,
+            "channel": str(topic_channel.pk),
+        }
+
+        response = await user_auth_client.post(
+            "/oauth/token", data=data, auth=(integration.client_id, integration.client_secret)
+        )
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+        access_token = response.json()["access_token"]
+        refresh_token = response.json()["refresh_token"]
+
+        app_client = await get_app_authorized_client(
+            integration, channels=[topic_channel], access_token=access_token, refresh_token=refresh_token
+        )
+
+        await asyncio.sleep(1)
+
+        data = {"content": "gm!", "channel": str(topic_channel.pk)}
+        response = await app_client.post("/messages", json=data)
+        assert response.status_code == 401
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_oauth2_refresh_token_expiry(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+        monkeypatch,
+    ):
+        get_settings.cache_clear()
+        monkeypatch.setenv("JWT_REFRESH_TOKEN_EXPIRE_MINUTES", "0")
+        current_settings = await get_oauth_settings()
+        assert current_settings.REFRESH_TOKEN_EXPIRES_IN < 1
+
+        redirect_uri = "https://example.com"
+        app_schema = AppCreateSchema(name="Snapshot", redirect_uris=[redirect_uri], scopes=["messages.list"])
+        integration = await create_app(model=app_schema, current_user=current_user)
+
+        params = {
+            "client_id": integration.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": "messages.list",
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+        }
+
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data={"consent": 1})
+        assert response.status_code == 200
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
+
+        params = parse_qs(url.query)
+        code = params.get("code")
+        assert code is not None
+        assert code != ""
+
+        data = {
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": redirect_uri,
+            "channel": str(topic_channel.pk),
+        }
+
+        response = await user_auth_client.post(
+            "/oauth/token", data=data, auth=(integration.client_id, integration.client_secret)
+        )
+        assert response.status_code == 200
+        refresh_token = response.json().get("refresh_token")
+
+        data = {
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+            "redirect_uri": redirect_uri,
+            "channel": str(topic_channel.pk),
+        }
+        response = await user_auth_client.post(
+            "/oauth/token", data=data, auth=(integration.client_id, integration.client_secret)
+        )
+        assert response.status_code == 400
+        json_response = response.json()
+        assert json_response["error"] == "invalid_grant"
+        get_settings.cache_clear()

--- a/app/tests/routers/test_oauth.py
+++ b/app/tests/routers/test_oauth.py
@@ -39,9 +39,6 @@ class TestOAuthRoutes:
             "state": state,
         }
 
-        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
-        assert response.status_code == 307
-
         form_data = {"consent": 1}
         user_auth_client = await get_authorized_client(current_user)
         response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
@@ -95,9 +92,6 @@ class TestOAuthRoutes:
             "response_type": "code",
         }
 
-        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
-        assert response.status_code == 307
-
         form_data = {"consent": 1}
         user_auth_client = await get_authorized_client(current_user)
         response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
@@ -129,9 +123,6 @@ class TestOAuthRoutes:
             "channel": str(topic_channel.pk),
             "state": state,
         }
-
-        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
-        assert response.status_code == 307
 
         form_data = {"consent": 0}
         user_auth_client = await get_authorized_client(current_user)
@@ -166,9 +157,6 @@ class TestOAuthRoutes:
             "state": state,
         }
 
-        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
-        assert response.status_code == 307
-
         form_data = {"consent": 1}
         guest_client = await get_authorized_client(guest_user)
         response = await guest_client.post("/oauth/authorize", params=params, data=form_data)
@@ -201,9 +189,6 @@ class TestOAuthRoutes:
             "channel": str(topic_channel.pk),
             "state": state,
         }
-
-        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
-        assert response.status_code == 307
 
         form_data = {"consent": 1}
         user_auth_client = await get_authorized_client(current_user)
@@ -238,9 +223,6 @@ class TestOAuthRoutes:
             "channel": str(topic_channel.pk),
             "state": state,
         }
-
-        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
-        assert response.status_code == 307
 
         form_data = {"consent": 1}
         user_auth_client = await get_authorized_client(current_user)
@@ -302,9 +284,6 @@ class TestOAuthRoutes:
             "channel": str(topic_channel.pk),
             "state": state,
         }
-
-        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
-        assert response.status_code == 307
 
         form_data = {"consent": 1}
         user_auth_client = await get_authorized_client(current_user)
@@ -368,9 +347,6 @@ class TestOAuthRoutes:
             "channel": str(topic_channel.pk),
             "state": state,
         }
-
-        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
-        assert response.status_code == 307
 
         form_data = {"consent": 1}
         user_auth_client = await get_authorized_client(current_user)

--- a/app/tests/routers/test_oauth.py
+++ b/app/tests/routers/test_oauth.py
@@ -138,3 +138,50 @@ class TestOAuthRoutes:
         response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
         assert response.status_code == 400
         assert "Consent not granted" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_oauth2_code_flow_guest_in_topic_channel_nok(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+        guest_user: User,
+    ):
+        redirect_uri = "https://example.com"
+        state = secrets.token_urlsafe(32)
+
+        app_schema = AppCreateSchema(name="test", redirect_uris=[redirect_uri])
+        integration = await create_app(model=app_schema, current_user=current_user)
+        assert integration is not None
+
+        params = {
+            "client_id": integration.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": "",
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+            "state": state,
+        }
+
+        response = await client.get("/oauth/authorize", params=params, follow_redirects=False)
+        assert response.status_code == 307
+
+        form_data = {"consent": 1}
+        guest_client = await get_authorized_client(guest_user)
+        response = await guest_client.post("/oauth/authorize", params=params, data=form_data)
+        assert response.status_code == 403
+
+        data = {
+            "code": "123123",
+            "client_id": integration.client_id,
+            "client_secret": integration.client_secret,
+            "grant_type": "authorization_code",
+            "redirect_uri": redirect_uri,
+            "channel": str(topic_channel.pk),
+        }
+
+        response = await guest_client.post("/oauth/token", data=data)
+        assert response.status_code == 403

--- a/app/tests/routers/test_oauth.py
+++ b/app/tests/routers/test_oauth.py
@@ -10,10 +10,12 @@ from pymongo.database import Database
 
 from app.config import get_settings
 from app.helpers.auth import get_oauth_settings
+from app.models.auth import AuthorizationCode
 from app.models.channel import Channel
 from app.models.user import User
 from app.schemas.apps import AppCreateSchema
 from app.services.apps import create_app
+from app.services.crud import get_item
 
 
 class TestOAuthRoutes:
@@ -73,10 +75,11 @@ class TestOAuthRoutes:
             "/oauth/token", data=data, auth=(integration.client_id, integration.client_secret)
         )
         assert response.status_code == 200
-        assert "access_token" in response.json()
-        assert "refresh_token" in response.json()
-        assert "expires_in" in response.json()
-        assert "token_type" in response.json()
+        json_resp = response.json()
+        assert "access_token" in json_resp
+        assert "refresh_token" in json_resp
+        assert "expires_in" in json_resp
+        assert "token_type" in json_resp
 
     @pytest.mark.asyncio
     async def test_oauth2_code_flow_missing_channel(
@@ -270,7 +273,7 @@ class TestOAuthRoutes:
         assert json_resp["scope"] == " ".join(auth_scopes)
 
     @pytest.mark.asyncio
-    async def test_oauth2_code_flow_default_client_scopes(
+    async def test_oauth2_code_flow_default_client_scopes_nok(
         self,
         app: FastAPI,
         db: Database,
@@ -652,3 +655,354 @@ class TestOAuthRoutes:
         json_response = response.json()
         assert json_response["error"] == "invalid_grant"
         get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "app_redirect_uris, request_redirect_uri",
+        [
+            (
+                ["https://example.com/newshades/callback"],
+                "https://example.com",
+            ),
+            (
+                ["https://example.com/newshades/callback"],
+                "https://example.com/newshades/callback &@foo.evil-user.net#@bar.evil-user.net/",
+            ),
+            (
+                ["https://example.com/newshades/callback", "https://newshades.xyz"],
+                "https://newshades.xyz.hack-it.com",
+            ),
+        ],
+    )
+    async def test_oauth2_code_flow_invalid_redirect_uris(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+        app_redirect_uris,
+        request_redirect_uri,
+    ):
+        app_schema = AppCreateSchema(name="test", redirect_uris=app_redirect_uris)
+        integration = await create_app(model=app_schema, current_user=current_user)
+
+        params = {
+            "client_id": integration.client_id,
+            "scope": "",
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+            "redirect_uri": request_redirect_uri,
+        }
+
+        form_data = {"consent": 1}
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
+        assert response.status_code == 400
+        assert "invalid redirect uri" in response.json().get("description").lower()
+
+    @pytest.mark.asyncio
+    async def test_oauth2_code_flow_double_redirect_uris(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+    ):
+        app_schema = AppCreateSchema(name="test", redirect_uris=["https://example.com/callback"])
+        integration = await create_app(model=app_schema, current_user=current_user)
+
+        params = {
+            "client_id": integration.client_id,
+            "scope": "",
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+            "redirect_uri": ["https://example.com/callback", "https://my-hack-site.com/callback"],
+        }
+
+        form_data = {"consent": 1}
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
+        assert response.status_code == 400
+        assert "invalid redirect uri" in response.json().get("description").lower()
+
+    @pytest.mark.asyncio
+    async def test_oauth2_code_flow_double_redirect_uris_2(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+    ):
+        redirect_uri = "https://example.com/callback"
+        app_schema = AppCreateSchema(name="test", redirect_uris=[redirect_uri])
+        integration = await create_app(model=app_schema, current_user=current_user)
+
+        params = {
+            "client_id": integration.client_id,
+            "scope": "",
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+            "redirect_uri": ["https://my-hack-site.com/callback", redirect_uri],
+        }
+
+        form_data = {"consent": 1}
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
+        assert response.status_code == 200
+        json_resp = response.json()
+
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}{url.path}" == redirect_uri
+
+        url_params: dict = parse_qs(url.query)
+        code = url_params.get("code", [])[0]
+        assert code is not None
+
+        code_item = await get_item(filters={"code": code, "app": integration.pk}, result_obj=AuthorizationCode)
+        assert code_item is not None
+        assert code_item.redirect_uri == redirect_uri
+
+    @pytest.mark.asyncio
+    async def test_oauth2_code_flow_scopes_upgrade_nok(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+    ):
+        redirect_uri = "https://example.com"
+        state = secrets.token_urlsafe(32)
+        app_scopes = ["messages.list", "messages.create"]
+        auth_scopes = ["messages.list"]
+
+        app_schema = AppCreateSchema(name="test", redirect_uris=[redirect_uri], scopes=app_scopes)
+        integration = await create_app(model=app_schema, current_user=current_user)
+
+        params = {
+            "client_id": integration.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": " ".join(auth_scopes),
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+            "state": state,
+        }
+
+        form_data = {"consent": 1}
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
+        assert response.status_code == 200
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
+
+        url_params: dict = parse_qs(url.query)
+        code = url_params.get("code")
+        assert code is not None
+        assert code != ""
+
+        redirect_state = url_params.get("state", [])[0]
+        assert redirect_state is not None
+        assert redirect_state != ""
+        assert redirect_state == state
+
+        data = {
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": redirect_uri,
+            "channel": str(topic_channel.pk),
+        }
+
+        token_scopes = ["messages.list", "messages.create"]
+        data["scope"] = " ".join(token_scopes)
+
+        response = await user_auth_client.post(
+            "/oauth/token", data=data, auth=(integration.client_id, integration.client_secret)
+        )
+        assert response.status_code == 400
+        json_resp = response.json()
+        assert json_resp.get("error") == "invalid_scope"
+
+    @pytest.mark.asyncio
+    async def test_oauth2_refresh_token_upgrade_scope_nok(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+    ):
+        redirect_uri = "https://example.com"
+        app_scopes = ["messages.list", "messages.create"]
+        app_schema = AppCreateSchema(name="Snapshot", redirect_uris=[redirect_uri], scopes=app_scopes)
+        integration = await create_app(model=app_schema, current_user=current_user)
+
+        original_auth_code_scopes = ["messages.list"]
+        params = {
+            "client_id": integration.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": " ".join(original_auth_code_scopes),
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+        }
+
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data={"consent": 1})
+        assert response.status_code == 200
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
+
+        params = parse_qs(url.query)
+        code = params.get("code")
+        assert code is not None
+        assert code != ""
+
+        data = {
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": redirect_uri,
+            "channel": str(topic_channel.pk),
+        }
+
+        response = await user_auth_client.post(
+            "/oauth/token", data=data, auth=(integration.client_id, integration.client_secret)
+        )
+        assert response.status_code == 200
+        refresh_token = response.json().get("refresh_token")
+
+        refresh_scopes = original_auth_code_scopes.copy()
+        refresh_scopes.append("messages.create")
+
+        data = {
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+            "redirect_uri": redirect_uri,
+            "channel": str(topic_channel.pk),
+            "scope": " ".join(refresh_scopes),
+        }
+        response = await user_auth_client.post(
+            "/oauth/token", data=data, auth=(integration.client_id, integration.client_secret)
+        )
+        assert response.status_code == 200
+        json_resp = response.json()
+        assert "access_token" in json_resp
+        assert "refresh_token" in json_resp
+        assert "scope" in json_resp
+        assert json_resp.get("scope") == " ".join(original_auth_code_scopes)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "grant_type",
+        ["password", "client_credentials"],
+    )
+    async def test_oauth2_post_token_not_implemented_grant_types(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+        grant_type,
+    ):
+        redirect_uri = "https://example.com"
+        app_scopes = ["messages.list", "messages.create"]
+        app_schema = AppCreateSchema(name="Snapshot", redirect_uris=[redirect_uri], scopes=app_scopes)
+        integration = await create_app(model=app_schema, current_user=current_user)
+
+        auth_scopes = ["messages.list"]
+        params = {
+            "client_id": integration.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": " ".join(auth_scopes),
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+        }
+
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data={"consent": 1})
+        assert response.status_code == 200
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
+
+        params = parse_qs(url.query)
+        code = params.get("code")
+        assert code is not None
+        assert code != ""
+
+        data = {
+            "code": code,
+            "grant_type": grant_type,
+            "redirect_uri": redirect_uri,
+            "channel": str(topic_channel.pk),
+        }
+
+        response = await user_auth_client.post(
+            "/oauth/token", data=data, auth=(integration.client_id, integration.client_secret)
+        )
+        assert response.status_code == 400
+        assert response.json().get("error", "") == "unauthorized_client"
+
+    @pytest.mark.asyncio
+    async def test_oauth2_post_token_not_supported_grant_types(
+        self,
+        app: FastAPI,
+        db: Database,
+        client: AsyncClient,
+        current_user: User,
+        topic_channel: Channel,
+        get_authorized_client: Callable,
+    ):
+        redirect_uri = "https://example.com"
+        app_scopes = ["messages.list", "messages.create"]
+        app_schema = AppCreateSchema(name="Snapshot", redirect_uris=[redirect_uri], scopes=app_scopes)
+        integration = await create_app(model=app_schema, current_user=current_user)
+
+        auth_scopes = ["messages.list"]
+        params = {
+            "client_id": integration.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": " ".join(auth_scopes),
+            "response_type": "code",
+            "channel": str(topic_channel.pk),
+        }
+
+        user_auth_client = await get_authorized_client(current_user)
+        response = await user_auth_client.post("/oauth/authorize", params=params, data={"consent": 1})
+        assert response.status_code == 200
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
+
+        params = parse_qs(url.query)
+        code = params.get("code")
+        assert code is not None
+        assert code != ""
+
+        data = {
+            "code": code,
+            "grant_type": "token",
+            "redirect_uri": redirect_uri,
+            "channel": str(topic_channel.pk),
+        }
+
+        response = await user_auth_client.post(
+            "/oauth/token", data=data, auth=(integration.client_id, integration.client_secret)
+        )
+        assert response.status_code == 400
+        assert response.json().get("error", "") == "unsupported_grant_type"

--- a/app/tests/routers/test_oauth.py
+++ b/app/tests/routers/test_oauth.py
@@ -1,9 +1,10 @@
 import secrets
 from typing import Callable
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastapi import FastAPI
-from httpx import URL, AsyncClient
+from httpx import AsyncClient
 from pymongo.database import Database
 
 from app.models.channel import Channel
@@ -43,14 +44,17 @@ class TestOAuthRoutes:
         user_auth_client = await get_authorized_client(current_user)
         response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
         assert response.status_code == 200
-        url: URL = response.url
-        assert f"{url.scheme}://{url.netloc.decode('ascii')}" == redirect_uri
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
 
-        code = url.params.get("code")
+        params = parse_qs(url.query)
+        code = params.get("code")
         assert code is not None
         assert code != ""
 
-        redirect_state = url.params.get("state")
+        redirect_state = params.get("state")[0]
         assert redirect_state is not None
         assert redirect_state != ""
         assert redirect_state == state
@@ -228,14 +232,17 @@ class TestOAuthRoutes:
         user_auth_client = await get_authorized_client(current_user)
         response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
         assert response.status_code == 200
-        url: URL = response.url
-        assert f"{url.scheme}://{url.netloc.decode('ascii')}" == redirect_uri
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
 
-        code = url.params.get("code")
+        params = parse_qs(url.query)
+        code = params.get("code")
         assert code is not None
         assert code != ""
 
-        redirect_state = url.params.get("state")
+        redirect_state = params.get("state")[0]
         assert redirect_state is not None
         assert redirect_state != ""
         assert redirect_state == state
@@ -289,14 +296,17 @@ class TestOAuthRoutes:
         user_auth_client = await get_authorized_client(current_user)
         response = await user_auth_client.post("/oauth/authorize", params=params, data=form_data)
         assert response.status_code == 200
-        url: URL = response.url
-        assert f"{url.scheme}://{url.netloc.decode('ascii')}" == redirect_uri
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
 
-        code = url.params.get("code")
+        params = parse_qs(url.query)
+        code = params.get("code")
         assert code is not None
         assert code != ""
 
-        redirect_state = url.params.get("state")
+        redirect_state = params.get("state")[0]
         assert redirect_state is not None
         assert redirect_state != ""
         assert redirect_state == state
@@ -407,8 +417,13 @@ class TestOAuthRoutes:
         user_auth_client = await get_authorized_client(current_user)
         response = await user_auth_client.post("/oauth/authorize", params=params, data={"consent": 1})
         assert response.status_code == 200
-        url: URL = response.url
-        code = url.params.get("code")
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
+
+        params = parse_qs(url.query)
+        code = params.get("code")
         assert code is not None
         assert code != ""
 
@@ -457,8 +472,13 @@ class TestOAuthRoutes:
         user_auth_client = await get_authorized_client(current_user)
         response = await user_auth_client.post("/oauth/authorize", params=params, data={"consent": 1})
         assert response.status_code == 200
-        url: URL = response.url
-        code = url.params.get("code")
+        json_resp = response.json()
+        location = json_resp.get("location")
+        url = urlparse(location)
+        assert f"{url.scheme}://{url.netloc}" == redirect_uri
+
+        params = parse_qs(url.query)
+        code = params.get("code")
         assert code is not None
         assert code != ""
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,10 +1,13 @@
 [[package]]
 name = "aioauth"
-version = "1.4.1"
+version = "1.5.0"
 description = "Asynchronous OAuth 2.0 framework for Python 3."
 category = "main"
 optional = false
 python-versions = ">=3.7.0"
+
+[package.dependencies]
+typing-extensions = "*"
 
 [package.extras]
 fastapi = ["aioauth-fastapi (>=0.0.1)"]
@@ -1625,7 +1628,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "0bf60e362158e37ccb3a12ee0aadcfd046c3c3c02af41eeeabe1f74426224ce8"
+content-hash = "37e061b763360279bfdd8d401ad1256855455d05d1ae9d3487684da3b421bc31"
 
 [metadata.files]
 aioauth = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,18 +1,15 @@
 [[package]]
 name = "aioauth"
-version = "1.4.0"
+version = "1.4.1"
 description = "Asynchronous OAuth 2.0 framework for Python 3."
 category = "main"
 optional = false
 python-versions = ">=3.7.0"
 
-[package.dependencies]
-aioauth-fastapi = {version = ">=0.0.1", optional = true, markers = "extra == \"fastapi\""}
-
 [package.extras]
-dev = ["async-asgi-testclient (==1.4.8)", "pre-commit (==2.16.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-cov (==3.0.0)", "pytest-env (==0.6.2)", "pytest-sugar (==0.9.4)", "testfixtures (==6.18.3)", "bump2version (==1.0.1)", "twine (==3.7.1)", "wheel"]
-docs = ["sphinx", "sphinx-copybutton", "sphinx-autobuild", "m2r2", "sphinx-rtd-theme", "async-asgi-testclient (==1.4.8)", "pre-commit (==2.16.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-cov (==3.0.0)", "pytest-env (==0.6.2)", "pytest-sugar (==0.9.4)", "testfixtures (==6.18.3)", "bump2version (==1.0.1)", "twine (==3.7.1)", "wheel"]
 fastapi = ["aioauth-fastapi (>=0.0.1)"]
+docs = ["wheel", "twine (==3.7.1)", "bump2version (==1.0.1)", "testfixtures (==6.18.3)", "pytest-sugar (==0.9.4)", "pytest-env (==0.6.2)", "pytest-cov (==3.0.0)", "pytest-asyncio (==0.16.0)", "pytest (==6.2.5)", "pre-commit (==2.16.0)", "async-asgi-testclient (==1.4.8)", "sphinx-rtd-theme", "m2r2", "sphinx-autobuild", "sphinx-copybutton", "sphinx"]
+dev = ["wheel", "twine (==3.7.1)", "bump2version (==1.0.1)", "testfixtures (==6.18.3)", "pytest-sugar (==0.9.4)", "pytest-env (==0.6.2)", "pytest-cov (==3.0.0)", "pytest-asyncio (==0.16.0)", "pytest (==6.2.5)", "pre-commit (==2.16.0)", "async-asgi-testclient (==1.4.8)"]
 
 [[package]]
 name = "aioauth-fastapi"
@@ -1639,13 +1636,10 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "7ca5f860f701b04ff992ffd8fc98e54a6942839d33d2856665673273ee80dd9d"
+content-hash = "9900a73c2401f2aeedd45e08dfecc722d30b804759babadd1f39b612d2fed2d9"
 
 [metadata.files]
-aioauth = [
-    {file = "aioauth-1.4.0-py2.py3-none-any.whl", hash = "sha256:fa810bf8383baee9fd986111b143d5af152d90b2c73bf2069b281c7f7a1ce4fd"},
-    {file = "aioauth-1.4.0.tar.gz", hash = "sha256:85de10bf73a82a2298248123cd6a789c2ea16ffdbfa7567fa358af49f46fa6a8"},
-]
+aioauth = []
 aioauth-fastapi = [
     {file = "aioauth_fastapi-0.1.1-py2.py3-none-any.whl", hash = "sha256:3951753c3ff193c57b4f83142a27e2b8a8e66298660a14a7565345236e1a5ca3"},
     {file = "aioauth_fastapi-0.1.1.tar.gz", hash = "sha256:07eecbdd72e2e703dff3a44eb129eeefc96ba5a6d650ba5c921e8dbf8a931e1a"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,17 +12,6 @@ docs = ["wheel", "twine (==3.7.1)", "bump2version (==1.0.1)", "testfixtures (==6
 dev = ["wheel", "twine (==3.7.1)", "bump2version (==1.0.1)", "testfixtures (==6.18.3)", "pytest-sugar (==0.9.4)", "pytest-env (==0.6.2)", "pytest-cov (==3.0.0)", "pytest-asyncio (==0.16.0)", "pytest (==6.2.5)", "pre-commit (==2.16.0)", "async-asgi-testclient (==1.4.8)"]
 
 [[package]]
-name = "aioauth-fastapi"
-version = "0.1.1"
-description = "aioauth integration for FastAPI."
-category = "main"
-optional = false
-python-versions = ">=3.6.0"
-
-[package.extras]
-dev = ["fastapi (==0.70.1)", "aioauth (==1.3.0)", "uvicorn (==0.16.0)", "wheel", "twine (==3.7.1)", "pydantic[dotenv] (==1.8.2)", "asyncpg (==0.25.0)", "SQLAlchemy[asyncio] (==1.4.28)", "orjson (==3.6.5)", "python-jose[pycryptodome] (==3.3.0)", "python-multipart (==0.0.5)", "alembic (==1.7.5)", "sqlmodel (==0.0.5)", "async-asgi-testclient (==1.4.9)", "pre-commit (==2.16.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-cov (==3.0.0)", "pytest-env (==0.6.2)", "pytest-sugar (==0.9.4)", "testfixtures (==6.18.3)", "bump2version (==1.0.1)"]
-
-[[package]]
 name = "aiohttp"
 version = "3.8.1"
 description = "Async http client/server framework (asyncio)"
@@ -1636,14 +1625,10 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "9900a73c2401f2aeedd45e08dfecc722d30b804759babadd1f39b612d2fed2d9"
+content-hash = "0bf60e362158e37ccb3a12ee0aadcfd046c3c3c02af41eeeabe1f74426224ce8"
 
 [metadata.files]
 aioauth = []
-aioauth-fastapi = [
-    {file = "aioauth_fastapi-0.1.1-py2.py3-none-any.whl", hash = "sha256:3951753c3ff193c57b4f83142a27e2b8a8e66298660a14a7565345236e1a5ca3"},
-    {file = "aioauth_fastapi-0.1.1.tar.gz", hash = "sha256:07eecbdd72e2e703dff3a44eb129eeefc96ba5a6d650ba5c921e8dbf8a931e1a"},
-]
 aiohttp = [
     {file = "aiohttp-3.8.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1ed0b6477896559f17b9eaeb6d38e07f7f9ffe40b9f0f9627ae8b9926ae260a8"},
     {file = "aiohttp-3.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7dadf3c307b31e0e61689cbf9e06be7a867c563d5a63ce9dca578f956609abf8"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,31 @@
 [[package]]
+name = "aioauth"
+version = "1.4.0"
+description = "Asynchronous OAuth 2.0 framework for Python 3."
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+
+[package.dependencies]
+aioauth-fastapi = {version = ">=0.0.1", optional = true, markers = "extra == \"fastapi\""}
+
+[package.extras]
+dev = ["async-asgi-testclient (==1.4.8)", "pre-commit (==2.16.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-cov (==3.0.0)", "pytest-env (==0.6.2)", "pytest-sugar (==0.9.4)", "testfixtures (==6.18.3)", "bump2version (==1.0.1)", "twine (==3.7.1)", "wheel"]
+docs = ["sphinx", "sphinx-copybutton", "sphinx-autobuild", "m2r2", "sphinx-rtd-theme", "async-asgi-testclient (==1.4.8)", "pre-commit (==2.16.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-cov (==3.0.0)", "pytest-env (==0.6.2)", "pytest-sugar (==0.9.4)", "testfixtures (==6.18.3)", "bump2version (==1.0.1)", "twine (==3.7.1)", "wheel"]
+fastapi = ["aioauth-fastapi (>=0.0.1)"]
+
+[[package]]
+name = "aioauth-fastapi"
+version = "0.1.1"
+description = "aioauth integration for FastAPI."
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.extras]
+dev = ["fastapi (==0.70.1)", "aioauth (==1.3.0)", "uvicorn (==0.16.0)", "wheel", "twine (==3.7.1)", "pydantic[dotenv] (==1.8.2)", "asyncpg (==0.25.0)", "SQLAlchemy[asyncio] (==1.4.28)", "orjson (==3.6.5)", "python-jose[pycryptodome] (==3.3.0)", "python-multipart (==0.0.5)", "alembic (==1.7.5)", "sqlmodel (==0.0.5)", "async-asgi-testclient (==1.4.9)", "pre-commit (==2.16.0)", "pytest (==6.2.5)", "pytest-asyncio (==0.16.0)", "pytest-cov (==3.0.0)", "pytest-env (==0.6.2)", "pytest-sugar (==0.9.4)", "testfixtures (==6.18.3)", "bump2version (==1.0.1)"]
+
+[[package]]
 name = "aiohttp"
 version = "3.8.1"
 description = "Async http client/server framework (asyncio)"
@@ -1612,9 +1639,17 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "2feb4fa6745d78c8ca661741a81fa74e6a3cc666d445acf115a63b366e8d0a94"
+content-hash = "7ca5f860f701b04ff992ffd8fc98e54a6942839d33d2856665673273ee80dd9d"
 
 [metadata.files]
+aioauth = [
+    {file = "aioauth-1.4.0-py2.py3-none-any.whl", hash = "sha256:fa810bf8383baee9fd986111b143d5af152d90b2c73bf2069b281c7f7a1ce4fd"},
+    {file = "aioauth-1.4.0.tar.gz", hash = "sha256:85de10bf73a82a2298248123cd6a789c2ea16ffdbfa7567fa358af49f46fa6a8"},
+]
+aioauth-fastapi = [
+    {file = "aioauth_fastapi-0.1.1-py2.py3-none-any.whl", hash = "sha256:3951753c3ff193c57b4f83142a27e2b8a8e66298660a14a7565345236e1a5ca3"},
+    {file = "aioauth_fastapi-0.1.1.tar.gz", hash = "sha256:07eecbdd72e2e703dff3a44eb129eeefc96ba5a6d650ba5c921e8dbf8a931e1a"},
+]
 aiohttp = [
     {file = "aiohttp-3.8.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1ed0b6477896559f17b9eaeb6d38e07f7f9ffe40b9f0f9627ae8b9926ae260a8"},
     {file = "aiohttp-3.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7dadf3c307b31e0e61689cbf9e06be7a867c563d5a63ce9dca578f956609abf8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ uvicorn = "^0.16"
 uvloop = "^0.16"
 watchgod = "^0.7"
 web3 = "^5.26"
-aioauth = {extras = ["fastapi"], version = "^1.4.0"}
+aioauth = "^1.4.1"
 aioauth-fastapi = "^0.1.1"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ uvloop = "^0.16"
 watchgod = "^0.7"
 web3 = "^5.26"
 aioauth = "^1.4.1"
-aioauth-fastapi = "^0.1.1"
 
 [tool.poetry.dev-dependencies]
 black = { version = "*", allow-prereleases = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ uvicorn = "^0.16"
 uvloop = "^0.16"
 watchgod = "^0.7"
 web3 = "^5.26"
-aioauth = "^1.4.1"
+aioauth = "^1.5.0"
 
 [tool.poetry.dev-dependencies]
 black = { version = "*", allow-prereleases = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ uvicorn = "^0.16"
 uvloop = "^0.16"
 watchgod = "^0.7"
 web3 = "^5.26"
+aioauth = {extras = ["fastapi"], version = "^1.4.0"}
+aioauth-fastapi = "^0.1.1"
 
 [tool.poetry.dev-dependencies]
 black = { version = "*", allow-prereleases = true }


### PR DESCRIPTION
This PR is the first step towards allowing users to build and connect their own apps/bots to newshades. A bit like [slack](https://slack.com/apps) or [github](https://github.com/marketplace?type=apps)'s app marketplaces.

To do this, I implemented a simple oauth2 [authorization code](https://www.rfc-editor.org/rfc/rfc6749#section-4.1) flow that allows a user (with the right permissions) to install apps into a channel. After the oauth2 flow is successfully done, the app will get access and refresh tokens to interact with the API.

To begin with, some of the APIs might not support app authentication, but that will change with time.